### PR TITLE
sign_rpm_ext: set default GPG_PATH if it is not specified

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -15,3 +15,18 @@ RPM_FSK_PATH ?= "${@uks_ima_keys_dir(d) + 'x509_ima.key'}"
 RPM_FSK_PASSWORD ?= "password"
 
 inherit sign_rpm user-key-store
+
+python () {
+    gpg_path = d.getVar('GPG_PATH', True)
+    if not gpg_path:
+        gpg_path = d.getVar('DEPLOY_DIR_IMAGE', True) + '/.gnupg'
+
+        if not os.path.exists(gpg_path):
+            cmd = ' '.join(('mkdir -p', gpg_path))
+            status, output = oe.utils.getstatusoutput(cmd)
+            if status:
+                raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
+                                          (gpg_path, output))
+
+        d.setVar('GPG_PATH', gpg_path)
+}


### PR DESCRIPTION
commit 52bf3b6636f95a(meta-integrity: move gpg keyring initialization
to signing-keys) tried to initialize keyring in the task check_public_keys
of the recipe signing-keys. However, it does work with the recipe
signing-keys only, and GPG_PATH can't be passed to other recipes.

We bring the python anonymous function back, and it makes sure GPG_PATH
is set before signing the packages for every recipe.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>