### PR TITLE
sign_rpm_ext: Fix the GPG_PATH directory not exist issue

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -21,13 +21,12 @@ python () {
     gpg_path = d.getVar('GPG_PATH', True)
     if not gpg_path:
         gpg_path = d.getVar('DEPLOY_DIR_IMAGE', True) + '/.gnupg'
-
-        if not os.path.exists(gpg_path):
-            cmd = ' '.join(('mkdir -p', gpg_path))
-            status, output = oe.utils.getstatusoutput(cmd)
-            if status:
-                raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
-                                          (gpg_path, output))
-
         d.setVar('GPG_PATH', gpg_path)
+
+    if not os.path.exists(gpg_path):
+        cmd = ' '.join(('mkdir -p', gpg_path))
+        status, output = oe.utils.getstatusoutput(cmd)
+        if status:
+            raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
+                                      (gpg_path, output))
 }


### PR DESCRIPTION
If "GPG_PATH" is set in the init script, then "signing-keys"
get_public_keys task will execute failed.

So the "GPG_PATH" directory would be created when "GPG_PATH" is set.

The do_get_public_keys failed to import gpg key error information is as following:
----------------------------------------------------------------------------------------
ERROR: signing-keys-1.0-r0 do_get_public_keys: Function failed: Failed to import gpg key
(layers/meta-secure-core/meta-signing-key/files/rpm_keys/RPM-GPG-PRIVKEY-SecureCore):
gpg: fatal: can't create directory
`tmp/deploy/images/intel-corei7-64/.gnupg': No such file or directory

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>