### PR TITLE
Fix the user rpm sign key can not be found issue

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -29,10 +29,6 @@ def uks_ima_keys_dir(d):
     return d.getVar('IMA_KEYS_DIR', True) + '/'
 
 def uks_rpm_keys_dir(d):
-    # XXX: currently the user rpm pubkey is not supported.
-    if uks_signing_model(d) != 'sample':
-        return ''
-
     set_keys_dir('RPM', d)
     return d.getVar('RPM_KEYS_DIR', True) + '/'
 


### PR DESCRIPTION
When the SIGNING_MODEL is set to "user", the signing-keys recipes will
run failed on the get_public_keys task. uks_rpm_keys_dir() function
could not return the right rpm_keys directory when the
SIGNING_MODEL is set to "user".

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>