### PR TITLE
meta-integrity: import gpg key before do_package_write_rpm

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -22,3 +22,6 @@ python () {
             raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
                                       (gpg_path, output))
 }
+
+do_package_index[depends] += "signing-keys-native:do_check_public_keys"
+do_package_write_rpm[depends] += "signing-keys-native:do_check_public_keys"

--- a/meta-integrity/recipes-core/meta/signing-keys.bbappend
+++ b/meta-integrity/recipes-core/meta/signing-keys.bbappend
@@ -1,4 +1,4 @@
-python check_public_keys () {
+python do_check_public_keys () {
     gpg_path = d.getVar('GPG_PATH', True)
     gpg_bin = d.getVar('GPG_BIN', True) or \
               bb.utils.which(os.getenv('PATH'), 'gpg')
@@ -20,5 +20,9 @@ python check_public_keys () {
         raise bb.build.FuncFailed('Failed to import gpg key (%s): %s' %
                                   (gpg_key, output))
 }
-check_public_keys[lockfiles] = "${TMPDIR}/check_public_keys.lock"
-do_get_public_keys[prefuncs] += "check_public_keys"
+
+addtask do_check_public_keys before do_get_public_keys
+
+do_check_public_keys[lockfiles] = "${TMPDIR}/check_public_keys.lock"
+
+BBCLASSEXTEND="native"


### PR DESCRIPTION
os-release is almost the first target recipe built for a rootfs.
However, there is no dependency making sure gpg key is imported before
signing os-release recipe.

This commit defines that dependency and fixes the problem above.

Also make the signing-keys into a native recipe, as it is meanless to be
a target recipe.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>