### PR TITLE
key-store: Fix two key-store-rpm-pubkey user key issues

### DIFF
--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -27,7 +27,7 @@ SYSTEM_CERT = "${KEY_DIR}/system_trusted_key.crt"
 IMA_CERT = "${KEY_DIR}/x509_evm.der"
 
 python () {
-    if uks_signing_model(d) != "sample":
+    if not (uks_signing_model(d) in "sample", "user"):
         return
 
     pn = d.getVar('PN', True) + '-system-trusted-privkey'
@@ -42,8 +42,8 @@ python () {
 
     pn = d.getVar('PN', True) + '-rpm-pubkey'
     d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-*', True))
-    d.setVar('CONFFILES_' + pn, d.getVar(d.getVar('RPM_KEY_DIR', True) + 'RPM-GPG-KEY-*', True))
+    d.setVar('FILES_' + pn, d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-' + d.getVar('RPM_GPG_NAME', True))
+    d.setVar('CONFFILES_' + pn, d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-' + d.getVar('RPM_GPG_NAME', True))
     d.appendVar('RDEPENDS_' + pn, ' rpm')
 }
 
@@ -70,14 +70,14 @@ do_install() {
     key_dir="${@uks_system_trusted_keys_dir(d)}"
     install -m 0644 "$key_dir/system_trusted_key.crt" "${D}${SYSTEM_CERT}"
 
-    if [ "${@uks_signing_model(d)}" = "sample" ]; then
+    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
         install -m 0400 "$key_dir/system_trusted_key.key" "${D}${SYSTEM_PRIV_KEY}"
     fi
 
     key_dir="${@uks_ima_keys_dir(d)}"
     install -m 0644 "$key_dir/x509_ima.der" "${D}${IMA_CERT}"
 
-    if [ "${@uks_signing_model(d)}" = "sample" ]; then
+    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
         install -m 0400 "$key_dir/x509_ima.key" "${D}${IMA_PRIV_KEY}"
     fi
 }


### PR DESCRIPTION
According to Jia's valuable suggestions to add a condition to control the "sample" and "user" sign mode to create these packages.
 
1. user key pub rpm package also could be created.
2. The latest bitbake could not support the d.getVar() function nest
call. Such as the following function call always return "None"
d.getVar(d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-*', True)
It caused the key-store-rpm-pubkey rpm package could not be created in
the latest oe-core project.

Signed-off-by: Guojian Zhou <guojian.zhou@windriver.com>