### PR TITLE
kernel-initramfs: fix the issue rm kernel source codes

### DIFF
--- a/meta/recipes-core/images/kernel-initramfs.bb
+++ b/meta/recipes-core/images/kernel-initramfs.bb
@@ -11,7 +11,6 @@ PROVIDES = "virtual/kernel-initramfs"
 
 ALLOW_EMPTY_${PN} = "1"
 
-S = "${STAGING_KERNEL_DIR}"
 B = "${WORKDIR}/${BPN}-${PV}"
 
 inherit linux-kernel-base kernel-arch


### PR DESCRIPTION
The "${S}" is not used for kernel-initramfs and it will
cleanup the kernel source codes if it is specified to
${STAGING_KERNEL_DIR}, thus remove this definition.

Signed-off-by: Fupan Li <fupan.li@windriver.com>