### PR TITLE
Add lvm2-udevrules into cryptsetup RDEPENDS list.

### DIFF
--- a/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
+++ b/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
@@ -1,1 +1,1 @@
-RDEPENDS_${PN} += "lvm2"
+RDEPENDS_${PN} += "lvm2 lvm2-udevrules"


### PR DESCRIPTION
meta-oe layer split the udevrules for lvm2 into a new package.
Add lvm2-udevrules into cryptsetup RDEPENDS list.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>