### PR TITLE
keyutils: update to 1.5.10

### DIFF
--- a/meta-integrity/recipes-support/keyutils/keyutils/keyutils-remove-m32-m64.patch
+++ b/meta-integrity/recipes-support/keyutils/keyutils/keyutils-remove-m32-m64.patch
@@ -1,19 +1,38 @@
-Index: keyutils-1.5.5/Makefile
-===================================================================
---- keyutils-1.5.5.orig/Makefile	2011-12-20 11:05:10.000000000 +0200
-+++ keyutils-1.5.5/Makefile	2011-12-20 11:06:27.000000000 +0200
-@@ -58,12 +58,12 @@
- LNS		:= ln -sf
+From a47fef08f065003d417750abf1077387f755153f Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Tue, 26 Sep 2017 07:15:41 +0000
+Subject: [PATCH] keyutils: fix cflags for arm, aarch64, mips, mips64, powerpc
+
+Remove m32, m64 from the CFLAGS to fix error:
+
+  error: unrecognized command line option '-m32/-m64'
+
+Upstream-Status: Pending
+
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+---
+ Makefile | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index d24cc44..230d4b6 100644
+--- a/Makefile
++++ b/Makefile
+@@ -65,12 +65,12 @@ endif
+ BUILDFOR	:= $(shell file /usr/bin/make | sed -e 's!.*ELF \(32\|64\)-bit.*!\1!')-bit
  
  ifeq ($(BUILDFOR),32-bit)
 -CFLAGS		+= -m32
 +#CFLAGS		+= -m32
- LIBDIR		:= /usr/lib
+ LIBDIR		:= /lib
  USRLIBDIR	:= /usr/lib
  else
  ifeq ($(BUILDFOR),64-bit)
 -CFLAGS		+= -m64
 +#CFLAGS		+= -m64
- LIBDIR		:= /usr/lib
- USRLIBDIR	:= /usr/lib
+ LIBDIR		:= /lib64
+ USRLIBDIR	:= /usr/lib64
  endif
+-- 
+2.11.0
+

--- a/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_library_install.patch
+++ b/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_library_install.patch
@@ -1,30 +1,32 @@
-Index: keyutils-1.5.5/Makefile
-===================================================================
---- keyutils-1.5.5.orig/Makefile	2011-11-30 17:27:43.000000000 +0200
-+++ keyutils-1.5.5/Makefile	2011-12-21 16:05:53.000000000 +0200
-@@ -59,13 +59,13 @@
- 
- ifeq ($(BUILDFOR),32-bit)
- CFLAGS		+= -m32
--LIBDIR		:= /lib
-+LIBDIR		:= /usr/lib
- USRLIBDIR	:= /usr/lib
- else
- ifeq ($(BUILDFOR),64-bit)
- CFLAGS		+= -m64
--LIBDIR		:= /lib64
--USRLIBDIR	:= /usr/lib64
-+LIBDIR		:= /usr/lib
-+USRLIBDIR	:= /usr/lib
- endif
- endif
- 
-@@ -152,7 +152,7 @@
+From b0355cc205543ffd33752874295139d57c4fbc3e Mon Sep 17 00:00:00 2001
+From: Wenzong Fan <wenzong.fan@windriver.com>
+Date: Tue, 26 Sep 2017 07:59:51 +0000
+Subject: [PATCH] Subject: [PATCH] keyutils: use relative path for link
+
+The absolute path of the symlink will be invalid
+when populated in sysroot, so use relative path instead.
+
+Upstream-Status: Pending
+
+Signed-off-by: Jackie Huang <jackie.huang@windriver.com>
+Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index 824bbbf..8ce3a13 100644
+--- a/Makefile
++++ b/Makefile
+@@ -167,7 +167,7 @@ ifeq ($(NO_SOLIB),0)
  	$(INSTALL) -D $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(LIBNAME)
  	$(LNS) $(LIBNAME) $(DESTDIR)$(LIBDIR)/$(SONAME)
  	mkdir -p $(DESTDIR)$(USRLIBDIR)
 -	$(LNS) $(LIBDIR)/$(SONAME) $(DESTDIR)$(USRLIBDIR)/$(DEVELLIB)
 +	$(LNS) $(SONAME) $(DESTDIR)$(USRLIBDIR)/$(DEVELLIB)
+ endif
  	$(INSTALL) -D keyctl $(DESTDIR)$(BINDIR)/keyctl
  	$(INSTALL) -D request-key $(DESTDIR)$(SBINDIR)/request-key
- 	$(INSTALL) -D request-key-debug.sh $(DESTDIR)$(SHAREDIR)/request-key-debug.sh
+-- 
+2.11.0
+

--- a/meta-integrity/recipes-support/keyutils/keyutils_git.bb
+++ b/meta-integrity/recipes-support/keyutils/keyutils_git.bb
@@ -8,7 +8,7 @@ SECTION = "base"
 LICENSE = "GPLv2"
 LIC_FILES_CHKSUM = "file://LICENCE.GPL;md5=5f6e72824f5da505c1f4a7197f004b45"
 
-PV = "1.5.9+git${SRCPV}"
+PV = "1.5.10+git${SRCPV}"
 
 SRC_URI = "\
     git://git.kernel.org/pub/scm/linux/kernel/git/dhowells/keyutils.git \
@@ -22,11 +22,13 @@ SRC_URI_append_mips64 = " file://keyutils-remove-m32-m64.patch"
 SRC_URI_append_x86 = " file://keyutils_fix_x86_cflags.patch"
 SRC_URI_append_x86-64 = " file://keyutils_fix_x86-64_cflags.patch"
 SRC_URI_append_powerpc = "file://keyutils-remove-m32-m64.patch"
-SRCREV = "9209a0c8fd63afc59f644e078b40cec531409c30"
+SRCREV = "308119c61e94bcc4c710404b9f679e3bb8316713"
 
 S = "${WORKDIR}/git"
 
 inherit autotools-brokensep
+
+EXTRA_OEMAKE = "'CFLAGS=${CFLAGS} -Wall'"
 
 INSTALL_FLAGS = "\
     LIBDIR=${libdir} \
@@ -47,18 +49,3 @@ do_install() {
 FILES_${PN} += "${datadir}/request-key-debug.sh"
 
 BBCLASSEXTEND = "native nativesdk"
-
-inherit update-alternatives
-
-ALTERNATIVE_PRIORITY = "200"
-ALTERNATIVE_${PN}-doc = "keyrings.7 persistent-keyring.7 process-keyring.7 \
-                         session-keyring.7 thread-keyring.7 user-keyring.7 \
-                         user-session-keyring.7 \
-"
-ALTERNATIVE_LINK_NAME[keyrings.7] = "${mandir}/man7/keyrings.7"
-ALTERNATIVE_LINK_NAME[persistent-keyring.7] = "${mandir}/man7/persistent-keyring.7"
-ALTERNATIVE_LINK_NAME[process-keyring.7] = "${mandir}/man7/process-keyring.7"
-ALTERNATIVE_LINK_NAME[session-keyring.7] = "${mandir}/man7/session-keyring.7"
-ALTERNATIVE_LINK_NAME[thread-keyring.7] = "${mandir}/man7/thread-keyring.7"
-ALTERNATIVE_LINK_NAME[user-keyring.7] = "${mandir}/man7/user-keyring.7"
-ALTERNATIVE_LINK_NAME[user-session-keyring.7] = "${mandir}/man7/user-session-keyring.7"


### PR DESCRIPTION
* rebase patches:
  - keyutils_fix_library_install.patch
  - keyutils-remove-m32-m64.patch

* append '-Wall' to CFLAGS for fixing:
  .../recipe-sysroot/usr/include/features.h:376:4: error: \
  #warning _FORTIFY_SOURCE requires compiling with \
  optimization (-O) [-Werror=cpp]

* cleanup alternative targets, the *keyring*.7 files have been
  removed from keyutils 1.5.10.

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>