### PR TITLE
grub-efi: fix build error with qemux86

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/mok2verify-support-to-verify-non-PE-file-with-PKCS-7.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/mok2verify-support-to-verify-non-PE-file-with-PKCS-7.patch
@@ -322,7 +322,7 @@ index 0000000..3865661
 +      else
 +	{
 +	  grub_printf ("failed to verify file %s (err: 0x%lx)\n",
-+		       path, status);
++		       path, (long)status);
 +
 +	  return grub_error (GRUB_ERR_ACCESS_DENIED, "the file %s is not verified",
 +			     path);


### PR DESCRIPTION
Fix the error:
  mok2verify.c:169:53: error: \
  format '%lx' expects argument of type 'long unsigned int', \
  but argument 3 has type 'grub_efi_status_t {aka int}' \
  [-Werror=format=]

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>