### PR TITLE
shim: disable OVERRIDE_SECURITY_POLICY for 32bit target

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -64,9 +64,10 @@ EXTRA_OEMAKE = "\
     ${@'VENDOR_DBX_FILE=${WORKDIR}/vendor_dbx.esl' \
        if uks_signing_model(d) == 'user' else ''} \
     ENABLE_HTTPBOOT=1 \
-    OVERRIDE_SECURITY_POLICY=1 \
     ENABLE_SBSIGN=1 \
 "
+
+EXTRA_OEMAKE_append_x86-64 = " OVERRIDE_SECURITY_POLICY=1"
 
 PARALLEL_MAKE = ""
 COMPATIBLE_HOST = '(i.86|x86_64).*-linux'


### PR DESCRIPTION
Fix 32bit assembler errors:
  | /tmp/ccJyZFtJ.s: Assembler messages:
  | /tmp/ccJyZFtJ.s:268: Error: bad register name `%rsp)'
  | /tmp/ccJyZFtJ.s:269: Error: bad register name `%rdi'
  ...
  | make[1]: *** [<builtin>: security_policy.o] Error 1

Signed-off-by: Wenzong Fan <wenzong.fan@windriver.com>