### PR TITLE
meta-integrity: Add ima-inspect utility

### DIFF
--- a/meta-integrity/recipes-base/packagegroups/packagegroup-ima.bb
+++ b/meta-integrity/recipes-base/packagegroups/packagegroup-ima.bb
@@ -9,6 +9,7 @@ DEPENDS += "\
 
 RDEPENDS_${PN} += "\
     attr \
+    ima-inspect \
     util-linux-switch-root.static \
 "
 

--- a/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.11.bb
+++ b/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.11.bb
@@ -1,0 +1,11 @@
+LICENSE = "GPLv2+"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
+
+DEPENDS += "attr ima-evm-utils tclap"
+
+SRC_URI = "git://github.com/mgerstner/ima-inspect.git"
+SRCREV = "e912be2d2a9fdf30a9693a7fc5d6b2473990a71c"
+
+S = "${WORKDIR}/git"
+
+inherit autotools


### PR DESCRIPTION
ima_inspect is a small program that allows to give a human-readable
representation of the contents of the extended attributes (xattrs) that
the Linux IMA security subsystem creates and manages for files.

Signed-off-by: Tom Rini <trini@konsulko.com>