### PR TITLE
meta-integrity: Fix build problem on ima-inspect

### DIFF
--- a/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.11.bb
+++ b/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.11.bb
@@ -8,4 +8,4 @@ SRCREV = "e912be2d2a9fdf30a9693a7fc5d6b2473990a71c"
 
 S = "${WORKDIR}/git"
 
-inherit autotools
+inherit autotools pkgconfig


### PR DESCRIPTION
The sources require that we have pkgconfig support as well, add missing
inherit.

Signed-off-by: Tom Rini <trini@konsulko.com>