### PR TITLE
keyutils: refresh patches to fix QA warning

### DIFF
--- a/meta-integrity/recipes-support/keyutils/keyutils/keyutils-fix-the-cflags-for-all-of-targets.patch
+++ b/meta-integrity/recipes-support/keyutils/keyutils/keyutils-fix-the-cflags-for-all-of-targets.patch
@@ -1,4 +1,4 @@
-From 8a1331d4abf9a96ee65e5fb31a00c7a2e0eed7c8 Mon Sep 17 00:00:00 2001
+From 104146d812a5591738235699b02fc8ae3fc44743 Mon Sep 17 00:00:00 2001
 From: Lei Maohui <leimaohui at cn.fujitsu.com>
 Date: Mon, 17 Aug 2015 13:53:28 +0900
 Subject: [PATCH] fix the cflags for all of targets.
@@ -9,19 +9,19 @@ Signed-off-by: Lei Maohui <leimaohui at cn.fujitsu.com>
  1 file changed, 2 deletions(-)
 
 diff --git a/Makefile b/Makefile
-index e2d7e2d..82e1a0f 100644
+index 824bbbf..d24cc44 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -64,7 +64,6 @@ BUILDFOR	:= $(shell file /usr/bin/make | sed -e 's!.*ELF \(32\|64\)-bit.*!\1!')-
- 
- LNS		:= ln -sf
+@@ -64,7 +64,6 @@ USRLIBDIR	:= $(patsubst /lib/%,/usr/lib/%,$(LIBDIR))
+ endif
+ BUILDFOR	:= $(shell file /usr/bin/make | sed -e 's!.*ELF \(32\|64\)-bit.*!\1!')-bit
  
 -ifeq ($(origin CFLAGS),undefined)
  ifeq ($(BUILDFOR),32-bit)
  CFLAGS		+= -m32
- LIBDIR		   := /usr/lib
-@@ -76,7 +75,6 @@ LIBDIR     := /usr/lib
- USRLIBDIR	:= /usr/lib
+ LIBDIR		:= /lib
+@@ -76,7 +75,6 @@ LIBDIR		:= /lib64
+ USRLIBDIR	:= /usr/lib64
  endif
  endif
 -endif
@@ -29,4 +29,5 @@ index e2d7e2d..82e1a0f 100644
  ###############################################################################
  #
 -- 
-1.8.4.2
+2.7.4
+

--- a/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_x86-64_cflags.patch
+++ b/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_x86-64_cflags.patch
@@ -1,4 +1,4 @@
-From d3b6b98984a28e782cb22dc6c7bd0ea9a0e74f15 Mon Sep 17 00:00:00 2001
+From f280d5af1d8654eaf1d767cf36abf3906b0fe3de Mon Sep 17 00:00:00 2001
 From: Lei Maohui <leimaohui at cn.fujitsu.com>
 Date: Mon, 17 Aug 2015 15:53:02 +0900
 Subject: [PATCH] keyutils fix x86-64 cflags
@@ -8,17 +8,18 @@ Subject: [PATCH] keyutils fix x86-64 cflags
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index 82e1a0f..23aa466 100644
+index d24cc44..968ee84 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -60,7 +60,7 @@ endif
+@@ -62,7 +62,7 @@ endif
  ifeq ($(origin USRLIBDIR),undefined)
  USRLIBDIR	:= $(patsubst /lib/%,/usr/lib/%,$(LIBDIR))
  endif
 -BUILDFOR	:= $(shell file /usr/bin/make | sed -e 's!.*ELF \(32\|64\)-bit.*!\1!')-bit
 +BUILDFOR	:= 64-bit
  
- LNS		:= ln -sf
- 
---
-1.8.4.2
+ ifeq ($(BUILDFOR),32-bit)
+ CFLAGS		+= -m32
+-- 
+2.7.4
+

--- a/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_x86_cflags.patch
+++ b/meta-integrity/recipes-support/keyutils/keyutils/keyutils_fix_x86_cflags.patch
@@ -1,4 +1,4 @@
-From 3263917382af02e61f12f3774c32d3324a57059f Mon Sep 17 00:00:00 2001
+From fc675bd1e977a1bf04a3ba884476939461207bec Mon Sep 17 00:00:00 2001
 From: Lei Maohui <leimaohui at cn.fujitsu.com>
 Date: Mon, 17 Aug 2015 11:48:22 +0900
 Subject: [PATCH] keyutils fix x86 cflags
@@ -8,17 +8,18 @@ Subject: [PATCH] keyutils fix x86 cflags
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/Makefile b/Makefile
-index e2d7e2d..f05bada 100644
+index d24cc44..899d95e 100644
 --- a/Makefile
 +++ b/Makefile
-@@ -60,7 +60,7 @@ endif
+@@ -62,7 +62,7 @@ endif
  ifeq ($(origin USRLIBDIR),undefined)
  USRLIBDIR	:= $(patsubst /lib/%,/usr/lib/%,$(LIBDIR))
  endif
 -BUILDFOR	:= $(shell file /usr/bin/make | sed -e 's!.*ELF \(32\|64\)-bit.*!\1!')-bit
 +BUILDFOR	:= 32-bit
  
- LNS		:= ln -sf
- 
---
-1.8.4.2
+ ifeq ($(BUILDFOR),32-bit)
+ CFLAGS		+= -m32
+-- 
+2.7.4
+


### PR DESCRIPTION
Refresh the following patches:
keyutils-fix-the-cflags-for-all-of-targets.patch
keyutils_fix_x86-64_cflags.patch
keyutils_fix_x86_cflags.patch

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>