### PR TITLE
initrdscripts-secure-core: Provide all directories init requires

### DIFF
--- a/meta/recipes-core/initrdscripts/initrdscripts-secure-core.bb
+++ b/meta/recipes-core/initrdscripts/initrdscripts-secure-core.bb
@@ -14,12 +14,18 @@ do_install() {
     # Create device nodes expected by kernel in initramfs
     # before executing /init.
     install -d "${D}/dev"
+    install -d "${D}/proc"
+    install -d "${D}/sys"
+    install -d "${D}/run"
     mknod -m 0600 "${D}/dev/console" c 5 1
 }
 
 FILES_${PN} = "\
     /init \
     /dev \
+    /proc \
+    /sys \
+    /run \
 "
 
 # Install the minimal stuffs only, and don't care how the external


### PR DESCRIPTION
Our "init" script requires additional directories to exist and since we
don't pull in something like base-files that gives us a full layout we
must make these additional directories on our own.

Signed-off-by: Tom Rini <trini@konsulko.com>