### PR TITLE
grub-efi: refresh patches to fix QA warning

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0003-efi-chainloader-implement-an-UEFI-Exit-service-for-s.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0003-efi-chainloader-implement-an-UEFI-Exit-service-for-s.patch
@@ -24,11 +24,11 @@ Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
  2 files changed, 27 insertions(+)
 
 diff --git a/grub-core/kern/x86_64/efi/callwrap.S b/grub-core/kern/x86_64/efi/callwrap.S
-index 2df95dd..f0f1dd8 100644
+index 1337fd9..b849c2c 100644
 --- a/grub-core/kern/x86_64/efi/callwrap.S
 +++ b/grub-core/kern/x86_64/efi/callwrap.S
 @@ -48,6 +48,26 @@ FUNCTION(efi_wrap_1)
- 	addq $48, %rsp
+ 	addq $40, %rsp
  	ret
  
 +FUNCTION(efi_call_foo)
@@ -52,20 +52,20 @@ index 2df95dd..f0f1dd8 100644
 +	ret
 +
  FUNCTION(efi_wrap_2)
- 	subq $48, %rsp
+ 	subq $40, %rsp
  	mov  %rsi, %rcx
 @@ -127,3 +147,6 @@ FUNCTION(efi_wrap_10)
  	call *%rdi
- 	addq $96, %rsp
+ 	addq $88, %rsp
  	ret
 +
 +	.data
 +saved_sp:	.quad   0
 diff --git a/include/grub/efi/api.h b/include/grub/efi/api.h
-index 26127de..374d88b 100644
+index c7c9f0e..af1c603 100644
 --- a/include/grub/efi/api.h
 +++ b/include/grub/efi/api.h
-@@ -1437,6 +1437,10 @@ typedef struct grub_efi_block_io grub_efi_block_io_t;
+@@ -1731,6 +1731,10 @@ typedef struct grub_efi_block_io grub_efi_block_io_t;
  
  grub_uint64_t EXPORT_FUNC(efi_wrap_0) (void *func);
  grub_uint64_t EXPORT_FUNC(efi_wrap_1) (void *func, grub_uint64_t arg1);

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0005-efi-chainloader-use-shim-to-load-and-verify-an-image.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0005-efi-chainloader-use-shim-to-load-and-verify-an-image.patch
@@ -19,18 +19,18 @@ Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
  1 file changed, 40 insertions(+), 9 deletions(-)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index bd83859..01d2ebe 100644
+index 1f8f061..e988945 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
-@@ -733,6 +733,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
-   grub_efi_loaded_image_t *loaded_image;
+@@ -739,6 +739,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
    char *filename;
+   void *boot_image = 0;
    grub_efi_handle_t dev_handle = 0;
 +  struct grub_shim_pe_coff_loader_image_context context;
  
    if (argc == 0)
      return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
-@@ -827,23 +828,53 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
+@@ -870,23 +871,53 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
    if (status != GRUB_EFI_SUCCESS)
      {
        if (status == GRUB_EFI_OUT_OF_RESOURCES)
@@ -91,8 +91,8 @@ index bd83859..01d2ebe 100644
 +  else
 +    loaded_image->device_handle = dev_handle;
  
-   grub_file_close (file);
- 
+   if (argc > 1)
+     {
 -- 
 1.9.1
 

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/Grub-get-and-set-efi-variables.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/Grub-get-and-set-efi-variables.patch
@@ -1,8 +1,16 @@
+From 00baa6144f07a103676d4831b31ab88aefbf736a Mon Sep 17 00:00:00 2001
+From: Lans Zhang <jia.zhang@windriver.com>
+Date: Thu, 22 Jun 2017 15:22:01 +0800
+
 ---
  grub-core/Makefile.core.def     |    8 +
  grub-core/commands/efi/efivar.c |  238 ++++++++++++++++++++++++++++++++++++++++
  2 files changed, 246 insertions(+)
+ create mode 100644 grub-core/commands/efi/efivar.c
 
+diff --git a/grub-core/commands/efi/efivar.c b/grub-core/commands/efi/efivar.c
+new file mode 100644
+index 0000000..6aeda80
 --- /dev/null
 +++ b/grub-core/commands/efi/efivar.c
 @@ -0,0 +1,238 @@
@@ -244,9 +252,11 @@
 +  if (cmd)
 +    grub_unregister_extcmd (cmd);
 +}
+diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
+index 7ce6609..a82c1f3 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -539,6 +539,14 @@ module = {
+@@ -691,6 +691,14 @@ module = {
  };
  
  module = {


### PR DESCRIPTION
Refresh the following patches:
  0003-efi-chainloader-implement-an-UEFI-Exit-service-for-s.patch
  0005-efi-chainloader-use-shim-to-load-and-verify-an-image.patch
  Grub-get-and-set-efi-variables.patch

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>