### PR TITLE
key-store: Fix typo in key-store-ima-privkey name

### DIFF
--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -57,7 +57,7 @@ python () {
     d.setVar('FILES_' + pn, d.getVar('MODSIGN_PRIV_KEY', True))
     d.setVar('CONFFILES_' + pn, d.getVar('MODSIGN_PRIV_KEY', True))
 
-    pn = d.getVar('PN', True) + 'ima-privkey'
+    pn = d.getVar('PN', True) + '-ima-privkey'
     d.setVar('PACKAGES_prepend', pn + ' ')
     d.setVar('FILES_' + pn, d.getVar('IMA_PRIV_KEY', True))
     d.setVar('CONFFILES_' + pn, d.getVar('IMA_PRIV_KEY', True))


### PR DESCRIPTION
We're missing a leading '-' when we combine pn and ima-privkey here,
add.

Signed-off-by: Michael Grigorov <michael.grigorov@konsulko.com>
Signed-off-by: Tom Rini <trini@konsulko.com>