### PR TITLE
grub-efi: blacklist it for arm64

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -23,6 +23,9 @@ SRC_URI += "\
     ${EXTRA_SRC_URI} \
 "
 
+# functions efi_call_foo and efi_shim_exit are not implemented for arm64 yet
+COMPATIBLE_HOST_aarch64 = 'null'
+
 EFI_BOOT_PATH = "/boot/efi/EFI/BOOT"
 
 GRUB_BUILDIN_append += " chain ${@'efivar mok2verify password_pbkdf2' \


### PR DESCRIPTION
I am sorry first that I don't recall why grub-efi built pass when I tested with last pull request. It fails to do mkimage on arm64 with error mesage:

| DEBUG: SITE files ['endian-little', 'bit-64', 'arm-common', 'arm-64', 'common-linux', 'common-glibc', 'aarch64-linux', 'common']
| DEBUG: Executing shell function do_mkimage
| grub-mkimage: error: undefined symbol efi_call_foo.
| WARNING: exit code 1 from a shell command.
| ERROR: Function failed: do_mkimage (log file is located at /home/wrlbuild/builds/builds-482b0a58-77bd-48d4-a928-65567f43909a/wrlinux-std-sato_qemuarm64_world_18/tmp-glibc/work/aarch64-wrs-linux/grub-efi/2.02-r0/temp/log.do_mkimage.321458)



Functions efi_call_foo and efi_shim_exit are not implemented for arm64,
so blacklist grub-efi for arm64 for now.

Signed-off-by: Kai Kang <kai.kang@windriver.com>