### PR TITLE
grub-efi: remove aarch64 from COMPATIBLE_HOST

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -23,6 +23,9 @@ SRC_URI += "\
     ${EXTRA_SRC_URI} \
 "
 
+# functions efi_call_foo and efi_shim_exit are not implemented for arm64 yet
+COMPATIBLE_HOST_aarch64 = 'null'
+
 EFI_BOOT_PATH = "/boot/efi/EFI/BOOT"
 
 GRUB_BUILDIN_append += " chain ${@'efivar mok2verify password_pbkdf2' \


### PR DESCRIPTION
Functions efi_call_foo and efi_shim_exit are not implemented for arm64
yet, so remove 'aarch64' from COMPATIBLE_HOST for now.

Signed-off-by: Kai Kang <kai.kang@windriver.com>