### PR TITLE
sign_rpm_ext.bbclass: check rpm public key at image recipe parsing time

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -47,4 +47,8 @@ python () {
         if status:
             raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
                                       (gpg_path, output))
+
+    is_image = bb.data.inherits_class('image', d)
+    if is_image:
+        bb.build.exec_func("check_rpm_public_key", d)
 }


### PR DESCRIPTION
While multiple builds share a common sstate, the latter
build failed to build image which the public key not found.
...
|ERROR: initramfs-ostree-image-1.0-r0 do_rootfs: Importing GPG key failed.
Command 'rpmkeys --root=<path>/rootfs --import <path>/rpm-key' returned 1:
...

The latter build will not regenerate rpm packages and
check_rpm_public_key will not be invoked.

Explicitly invoke check_rpm_public_key at image recipe parsing time,
which make sure gpg public key be imported.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>