### PR TITLE
sign_rpm_ext.bbclass: fix check_rpm_public_key racing at recipe parsi…

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -34,6 +34,7 @@ python check_rpm_public_key () {
 }
 check_rpm_public_key[lockfiles] = "${TMPDIR}/check_rpm_public_key.lock"
 do_package_write_rpm[prefuncs] += "check_rpm_public_key"
+do_rootfs[prefuncs] += "check_rpm_public_key"
 check_rpm_public_key[prefuncs] += "check_deploy_keys"
 
 python () {
@@ -47,8 +48,4 @@ python () {
         if status:
             raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
                                       (gpg_path, output))
-
-    is_image = bb.data.inherits_class('image', d)
-    if is_image:
-        bb.build.exec_func("check_rpm_public_key", d)
 }


### PR DESCRIPTION
…ng time

All recipe will be parsed which caused lockfile of
check_rpm_public_key racing issue.
...
|WARNING: meta-secure-core/meta/recipes-core/images/secure-core-image-initramfs.bb:
oe-core/bitbake/lib/bb/utils.py:400: ResourceWarning: unclosed file
<_io.TextIOWrapper name='tmp-glibc/check_rpm_public_key.lock' mode='a+' encoding='UTF-8'>
...

Refer do_package_write_rpm, add check_rpm_public_key to
prefunc of do_rootfs, only the running image recipe will
invoke check_rpm_public_key.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>