### PR TITLE
tpm2-abrmd-init: fix for /dev/tpmrmX

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-abrmd/files/tpm2-abrmd-init.sh
+++ b/meta-tpm2/recipes-tpm/tpm2-abrmd/files/tpm2-abrmd-init.sh
@@ -27,7 +27,7 @@ case "${1}" in
 	start)
 		echo -n "Starting $DESC: "
 
-		if [ ! -e /dev/tpm* ]
+		if [ ! -e /dev/tpm? ]
 		then
 			echo "device driver not loaded, skipping."
 			exit 0


### PR DESCRIPTION
In addition to the expected /dev/tpmX device nodes, newer Linux kernels now
also create /dev/tpmrmX nodes. This causes the daemon's startup script to
fail, meaning the abrmd daemon is not started automatically.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>