### PR TITLE
Add root parameter configuration in boot command line.

### DIFF
--- a/README
+++ b/README
@@ -92,6 +92,10 @@ DEBUG_FLAGS_forcevariable = ""
 IMAGE_INSTALL += "kernel-image-bzimage"
 USER_CLASSES_remove = "image-prelink"
 
+# Uncomment this line to modify the root parameter in boot command line if the default one
+# is not working for you. It is helpful when secure boot is enabled.
+#BOOT_CMD_ROOT = "/dev/hda2"
+
 III. Build meta-secure-core
 ===========================
 

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -76,6 +76,12 @@ do_install_append_class-target() {
             sed -i 's/^\s*linux\s\+.*bzImage.*/& ima_policy=tcb/g' "$menu"
     }
 
+    # Replace the root parameter in boot command line with BOOT_CMD_ROOT,
+    # which can be configured. It is helpful when secure boot is enabled.
+    [ -n "${BOOT_CMD_ROOT}" ] && {
+        sed -i "s,root=/dev/hda2,root=${BOOT_CMD_ROOT},g" "$menu"
+    }
+
     # Install the stacked grub configs.
     install -d "${D}${EFI_BOOT_PATH}"
     install -m 0600 "${WORKDIR}/grub-efi.cfg" "${D}${EFI_BOOT_PATH}/grub.cfg"


### PR DESCRIPTION
It is helpful when secure boot is enabled, because you can not
modify boot command line after boot-menu.inc is signed before deploying.

Signed-off-by: Jinliang Li <jinliang.li@linux.alibaba.com>