### PR TITLE
Fix parsing bug where SYSTEM_TRUSTED and SECONDARY_TRUSTED were always parsed as true

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -11,8 +11,8 @@ UEFI_SB = '${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "1", "0", 
 MOK_SB = '${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "1", "0", d)}'
 MODSIGN = '${@bb.utils.contains("DISTRO_FEATURES", "modsign", "1", "0", d)}'
 IMA = '${@bb.utils.contains("DISTRO_FEATURES", "ima", "1", "0", d)}'
-SYSTEM_TRUSTED = '${@"1" if d.getVar("IMA", True) or d.getVar("MODSIGN", True) else "0"}'
-SECONDARY_TRUSTED = '${@"1" if d.getVar("SYSTEM_TRUSTED", True) else "0"}'
+SYSTEM_TRUSTED = '${@"1" if d.getVar("IMA", True) == "1" or d.getVar("MODSIGN", True) == "1" else "0"}'
+SECONDARY_TRUSTED = '${@"1" if d.getVar("SYSTEM_TRUSTED", True) == "1" else "0"}'
 RPM = '1'
 
 def vprint(str, d):


### PR DESCRIPTION
SYSTEM_TRUSTED and SECONDARY_TRUSTED are being incorrectly parsed, so that they are always set to "1".

For instance, if d.getVar("IMA", True) or d.getVar("MODSIGN", True) looks as though it should return false, if both IMA and MODSIGN != "0". However, SYSTEM_TRUSTED is set to "1" instead of "0".

Doing an explicit check of '== 1' fixes this, at the expense of looking ugly. I have tested the opposite; making sure that when the result should be true, the variables are set to 1, and this works as before.