### PR TITLE
util-linux: allow -static linking for switch_root.static

### DIFF
--- a/meta-integrity/recipes-core/util-linux/util-linux_%.bbappend
+++ b/meta-integrity/recipes-core/util-linux/util-linux_%.bbappend
@@ -1,7 +1,9 @@
 CFLAGS_remove += "-pie -fpie"
 
+# We need -no-pie in case the default is to generate pie code.
+#
 do_compile_append_class-target() {
-    ${CC} ${CFLAGS} ${LDFLAGS} -static \
+    ${CC} ${CFLAGS} ${LDFLAGS} -no-pie -static \
         sys-utils/switch_root.o \
         -o switch_root.static
 }


### PR DESCRIPTION
Specify -no-pie to override possible -pie default.

Signed-off-by: Joe Slater <joe.slater@windriver.com>
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>