### PR TITLE
tpm2 git AUTOREV fix for BB_NO_NETWORK

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_git.bb
@@ -12,7 +12,13 @@ SRC_URI += " \
     file://tpm2-abrmd_git.default \
     "
 
-SRCREV = "${AUTOREV}"
+def version_git(d):
+    version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "cceb6c12ebb335aacb49207ee13d2f2fc833580a"
+SRCREV ?= '${@version_git(d)}'
 
 S = "${WORKDIR}/${BPN}"
 

--- a/meta-tpm2/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tools/tpm2-tools_git.bb
@@ -9,7 +9,13 @@ PV = "${PVBASE}.${SRCPV}"
 
 SRC_URI = "git://github.com/tpm2-software/${BPN}.git;protocol=git;branch=master;name=${BPN};destsuffix=${BPN}"
 
-SRCREV = "${AUTOREV}"
+def version_git(d):
+    version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "e105149f07c9b944f69599ab67cd8b018ad880d2"
+SRCREV ?= '${@version_git(d)}'
 
 S = "${WORKDIR}/${BPN}"
 

--- a/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_git.bb
@@ -13,7 +13,13 @@ PV = "${PVBASE}.${SRCPV}"
 
 SRC_URI = "git://github.com/tpm2-software/${BPN}.git;protocol=git;branch=master;name=${BPN};destsuffix=${BPN}"
 
-SRCREV = "${AUTOREV}"
+def version_git(d):
+    version = d.getVar("PREFERRED_VERSION_%s" % d.getVar('PN'))
+    if version is not None and "git" in version:
+        return d.getVar("AUTOREV")
+    else:
+        return "35ab16e1d328f709d6146221a371b7341b84b670"
+SRCREV ?= '${@version_git(d)}'
 
 S = "${WORKDIR}/${BPN}"
 


### PR DESCRIPTION
Bitbake will try an ls-remote for any recipe whose SRCREV is AUTOREV,
even if that recipe will not ultimately be used for a particular build.
Therefore if the user specifies 'BB_NO_NETWORK = "1"', the _git versions of
the tpm2 recipes will cause the build to fail even if the _git versions are
not going to be built (which they won't be by default on account of their
DEFAULT_PREFERENCE being set to "-1").

This fix follows the same pattern as
https://github.com/sbabic/meta-swupdate/commit/721fcc89c53debcd6582bd1aa972f75297cf12e9

With this fix, the user can disable networking and successfully build the
non-_git versions of the tpm2 recipes. If the user wants to build the _git
versions, networking must be enabled. The build is expected to fail if the
user asks for the _git versions, but disables networking.

Signed-off-by: Trevor Woerner <twoerner@gmail.com>