### PR TITLE
layer.conf: Include secure-core for kernel-initramfs.bb

### DIFF
--- a/meta-efi-secure-boot/conf/layer.conf
+++ b/meta-efi-secure-boot/conf/layer.conf
@@ -14,6 +14,7 @@ BBLAYERS_LAYERINDEX_NAME_efi-secure-boot = "meta-efi-secure-boot"
 LAYERDEPENDS_efi-secure-boot = "\
     core \
     openembedded-layer \
+    secure-core \
     signing-key \
     perl-layer \
 "


### PR DESCRIPTION
The kernel-initramfs.bbappend depends on kernel-initramfs.bb in
meta-secure-core/meta/recipes-core/images/

Fix parsing error:
ERROR: No recipes available for:
  meta-secure-core/meta-efi-secure-boot/recipes-core/images/kernel-initramfs.bbappend

Signed-off-by: Mark Hatle <mark.hatle@windriver.com>
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>