### PR TITLE
Make efi secure boot tools available to SDKs

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/gnu-efi/gnu-efi_%.bbappend
+++ b/meta-efi-secure-boot/recipes-bsp/gnu-efi/gnu-efi_%.bbappend
@@ -1,0 +1,1 @@
+BBCLASSEXTEND += "nativesdk"

--- a/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
+++ b/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
@@ -21,7 +21,7 @@ PV = "0.3.2+git${SRCPV}"
 SRC_URI = "\
     git://github.com/jiazhang0/libsign.git \
 "
-SRCREV = "0e8005f1c546ef25d834084f5cd85d386cf7cd1d"
+SRCREV = "1050db752d208fb3571167f154a1db0e031c3a09"
 
 PARALLEL_MAKE = ""
 
@@ -50,4 +50,4 @@ FILES_${PN} += "\
 RDEPENDS_${PN}_class-target += "libcrypto"
 RDEPENDS_${PN}_class-native += "openssl"
 
-BBCLASSEXTEND = "native"
+BBCLASSEXTEND = "native nativesdk"

--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -7,7 +7,7 @@ LIC_FILES_CHKSUM = "\
     file://COPYING;md5=a7710ac18adec371b84a9594ed04fd20 \
 "
 
-DEPENDS += "binutils-native openssl-native gnu-efi-native util-linux-native"
+DEPENDS += "binutils openssl gnu-efi util-linux"
 
 PV = "0.6+git${SRCPV}"
 
@@ -26,7 +26,7 @@ SRCREV="951ee95a301674c046f55330cd7460e1314deff2"
 
 S = "${WORKDIR}/git"
 
-inherit autotools-brokensep pkgconfig native
+inherit autotools-brokensep pkgconfig
 
 def efi_arch(d):
     import re
@@ -69,3 +69,5 @@ do_configure() {
     ./autogen.sh --noconfigure
     oe_runconf
 }
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
With this I can do:
# Include more tools into the SDK
TOOLCHAIN_HOST_TASK_append = " nativesdk-libsign nativesdk-libsign-dev"
TOOLCHAIN_HOST_TASK_append += "nativesdk-sbsigntool"

in local.conf and then bitbake -c populate_sdk include sbsign / selsign.  Note that we do need -dev for libsign.so to end up in the SDK and due to now selsign is linked it wants 'libsign.so' and not 'libsign.so.0' or similar.