### PR TITLE
cryptsetup_%.bbappend: move lvm2-udevrules from RDEPEND to RRECOMMENDS

### DIFF
--- a/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
+++ b/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
@@ -1,1 +1,2 @@
-RDEPENDS_${PN} += "lvm2 lvm2-udevrules"
+RDEPENDS_${PN} += "lvm2"
+RRECOMMENDS_${PN} += "lvm2-udevrules"


### PR DESCRIPTION
when configuring lvm2 without udev, lvm2-udevrules package is empty,
causing do_rootfs failure.

Error:
ERROR: wrlinux-image-glibc-std-1.0-r5 do_rootfs: Function failed: do_rootfs
 Problem: conflicting requests
  - nothing provides lvm2-udevrules needed by cryptsetup-1.7.4-r0.corei7_64

Move lvm2-udevrules from RDEPEND to RRECOMMENDS could workaround the issue.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>