### PR TITLE
key-store: fix incorrect postpone to first boot

### DIFF
--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -133,22 +133,20 @@ key_store_sysroot_preprocess() {
     sysroot_stage_dir "${D}${sysconfdir}" "${SYSROOT_DESTDIR}${sysconfdir}"
 }
 
-pkg_postinst_${PN}-rpm-pubkey() {
-    if [ -z "$D" ]; then
-        keydir="${RPM_KEY_DIR}"
+pkg_postinst_ontarget_${PN}-rpm-pubkey() {
+    keydir="${RPM_KEY_DIR}"
 
-        [ ! -d "$keydir" ] && mkdir -p "$keydir"
+    [ ! -d "$keydir" ] && mkdir -p "$keydir"
 
-        # XXX: only import the new key
-        for keyfile in `ls $keydir/RPM-GPG-KEY-*`; do
-            [ -s "$keyfile" ] || continue
+    # XXX: only import the new key
+    for keyfile in `ls $keydir/RPM-GPG-KEY-*`; do
+        [ -s "$keyfile" ] || continue
 
-            rpm --import "$keyfile" || {
-                echo "Unable to import the public key $keyfile"
-                exit 1
-            }
-        done
-    fi
+        rpm --import "$keyfile" || {
+            echo "Unable to import the public key $keyfile"
+            exit 1
+        }
+    done
 }
 
 PACKAGES = "\


### PR DESCRIPTION
After postinst was executed at do_rootfs successfully,
there will be no first boot to redo.

Since `229f4e9 package.bbclass: add support for
pkg_postinst_ontarget()' applied in oe-core, use
pkg_postinst_ontarget to instead.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>