### PR TITLE
layer.conf: update LAYERSERIES_COMPAT `sumo' -> `thud'

### DIFF
--- a/meta-efi-secure-boot/conf/layer.conf
+++ b/meta-efi-secure-boot/conf/layer.conf
@@ -19,4 +19,4 @@ LAYERDEPENDS_efi-secure-boot = "\
     perl-layer \
 "
 
-LAYERSERIES_COMPAT_efi-secure-boot = "sumo"
+LAYERSERIES_COMPAT_efi-secure-boot = "thud"

--- a/meta-encrypted-storage/conf/layer.conf
+++ b/meta-encrypted-storage/conf/layer.conf
@@ -17,4 +17,4 @@ LAYERDEPENDS_encrypted-storage = "\
     openembedded-layer \
 "
 
-LAYERSERIES_COMPAT_encrypted-storage = "sumo"
+LAYERSERIES_COMPAT_encrypted-storage = "thud"

--- a/meta-ids/conf/layer.conf
+++ b/meta-ids/conf/layer.conf
@@ -16,4 +16,4 @@ LAYERDEPENDS_ids = "\
     networking-layer \
 "
 
-LAYERSERIES_COMPAT_ids = "sumo"
+LAYERSERIES_COMPAT_ids = "thud"

--- a/meta-integrity/conf/layer.conf
+++ b/meta-integrity/conf/layer.conf
@@ -27,4 +27,4 @@ BB_HASHBASE_WHITELIST_append += "\
     RPM_FSK_PATH \
 "
 
-LAYERSERIES_COMPAT_integrity = "sumo"
+LAYERSERIES_COMPAT_integrity = "thud"

--- a/meta-intel-sgx/conf/layer.conf
+++ b/meta-intel-sgx/conf/layer.conf
@@ -15,4 +15,4 @@ LAYERDEPENDS_intel-sgx = "\
     core \
 "
 
-LAYERSERIES_COMPAT_intel-sgx = "rocko sumo"
+LAYERSERIES_COMPAT_intel-sgx = "rocko thud"

--- a/meta-signing-key/conf/layer.conf
+++ b/meta-signing-key/conf/layer.conf
@@ -13,7 +13,7 @@ BBLAYERS_LAYERINDEX_NAME_signing-key = "meta-signing-key"
 
 LAYERDEPENDS_signing-key = "core"
 
-LAYERSERIES_COMPAT_signing-key = "sumo"
+LAYERSERIES_COMPAT_signing-key = "thud"
 
 SIGNING_MODEL ??= "sample"
 SAMPLE_MOK_SB_KEYS_DIR = "${LAYERDIR}/files/mok_sb_keys"

--- a/meta-tpm/conf/layer.conf
+++ b/meta-tpm/conf/layer.conf
@@ -13,4 +13,4 @@ BBLAYERS_LAYERINDEX_NAME_tpm = "meta-tpm"
 
 LAYERDEPENDS_tpm = "core"
 
-LAYERSERIES_COMPAT_tpm = "sumo"
+LAYERSERIES_COMPAT_tpm = "thud"

--- a/meta-tpm2/conf/layer.conf
+++ b/meta-tpm2/conf/layer.conf
@@ -13,4 +13,4 @@ BBLAYERS_LAYERINDEX_NAME_tpm2 = "meta-tpm2"
 
 LAYERDEPENDS_tpm2 = "core"
 
-LAYERSERIES_COMPAT_tpm2 = "sumo"
+LAYERSERIES_COMPAT_tpm2 = "thud"

--- a/meta/conf/layer.conf
+++ b/meta/conf/layer.conf
@@ -15,4 +15,4 @@ LAYERDEPENDS_secure-core = "\
     core \
 "
 
-LAYERSERIES_COMPAT_secure-core = "sumo"
+LAYERSERIES_COMPAT_secure-core = "thud"


### PR DESCRIPTION
Since `9ec5a8a layer.conf: Drop sumo from LAYERSERIES_CORENAMES' and
`9867924 layer.conf: Add thud to LAYERSERIES_CORENAMES' applied in oe-core,
update LAYERSERIES_COMPAT `sumo' -> `thud'

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>