### PR TITLE
libsign: Fix build failure with GCC 8.x

### DIFF
--- a/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
+++ b/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
@@ -21,7 +21,7 @@ PV = "0.3.2+git${SRCPV}"
 SRC_URI = "\
     git://github.com/jiazhang0/libsign.git \
 "
-SRCREV = "353d5aaf0e8ab8cced360f6928dc4673054d696f"
+SRCREV = "36886d1055db5fd4efd7b5596d1f24e90187f539"
 
 PARALLEL_MAKE = ""
 


### PR DESCRIPTION
Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>