### PR TITLE
rpm: disable inhibit plugin for rpm-native

### DIFF
--- a/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
+++ b/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
@@ -6,3 +6,4 @@ PACKAGECONFIG = "${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'imaevm', '', d)
 EXTRA_OECONF_remove += "\
     --disable-plugins \
 "
+EXTRA_OECONF_append_class-native = " --disable-inhibit-plugin"


### PR DESCRIPTION
We have a bbappend file which enables plugins for rpm. We need to
ensure to also disable the inhibit plugin for rpm-native. Otherwise,
we get the following warning at rootfs time.

   Unable to get systemd shutdown inhibition lock: Socket name too long

The inhibit plugin tries to inhibit shutdown during rpm operation. It
obviously makes no sense for rpm-native, as 1) we may not build on a
systemd based host and 2) the build process does not affect the package
management on host.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>