### PR TITLE
initrdscripts-secure-core: remove /sys and /proc from package

### DIFF
--- a/meta/recipes-core/initrdscripts/initrdscripts-secure-core.bb
+++ b/meta/recipes-core/initrdscripts/initrdscripts-secure-core.bb
@@ -14,8 +14,6 @@ do_install() {
     # Create device nodes expected by kernel in initramfs
     # before executing /init.
     install -d "${D}/dev"
-    install -d "${D}/proc"
-    install -d "${D}/sys"
     install -d "${D}/run"
     mknod -m 0600 "${D}/dev/console" c 5 1
 }
@@ -23,8 +21,6 @@ do_install() {
 FILES_${PN} = "\
     /init \
     /dev \
-    /proc \
-    /sys \
     /run \
 "
 


### PR DESCRIPTION
The following failure is shown during secure-core-image-initramfs:do_rootfs():

Error: Transaction check error:
  file /proc conflicts between attempted installs of initrdscripts-secure-core-1.0-r0.corei7_64 and base-files-3.0.14-r89.intel_x86_64
  file /sys conflicts between attempted installs of initrdscripts-secure-core-1.0-r0.corei7_64 and base-files-3.0.14-r89.intel_x86_64

So remove /sys and /proc as base-files has already provided them.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>