### PR TITLE
meta-signing-key: When deploying keys UEFI keys, deploy DER format

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -336,6 +336,10 @@ deploy_uefi_sb_keys() {
         install -d "$deploy_dir"
 
         cp -af "${UEFI_SB_KEYS_DIR}"/* "$deploy_dir"
+        for KEY in DB KEK PK; do
+             openssl x509 -in "${UEFI_SB_KEYS_DIR}"/${KEY}.crt \
+                 -out "$deploy_dir"/${KEY}.cer -outform DER;
+        done
     fi
 }
 


### PR DESCRIPTION
Generally speaking, for firmware to import PK/KEK/DB keys they need to
be in the binary "DER" format and typically have the "cer" file
extension.  When deploying our keys, convert what we have to that format
and deploy as well for ease of use.

Signed-off-by: Tom Rini <trini@konsulko.com>
---
This would be good to merge to all branches once approved, should I send PRs for that or will you just cherry-pick it?  Thanks!