### PR TITLE
mtree: update context of configure.ac-automake-error.patch

### DIFF
--- a/meta-ids/recipes-ids/mtree/mtree/configure.ac-automake-error.patch
+++ b/meta-ids/recipes-ids/mtree/mtree/configure.ac-automake-error.patch
@@ -18,18 +18,18 @@ Signed-off-by: Robert Yang <liezhi.yang@windriver.com>
  1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/configure.ac b/configure.ac
-index bf228df..dc10bff 100644
+index 00cfc4a..dc59f73 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -6,7 +6,7 @@
+@@ -4,7 +4,7 @@
  
- AC_INIT([mtree Utility for creating and verifying file hierarchies], [1.0.2], [http://www.freebsd.org/], [mtree])
+ AC_INIT([mtree Utility for creating and verifying file hierarchies], [1.0.3], [http://www.freebsd.org/], [mtree])
  AC_CONFIG_AUX_DIR(scripts)
 -AM_INIT_AUTOMAKE
 +AM_INIT_AUTOMAKE([foreign])
  dnl AM_MAINTAINER_MODE
  AC_PREREQ(2.59)
- AC_REVISION($Id: configure.ac 15 2013-05-30 15:29:35Z archie.cobbs $)
+ AC_PREFIX_DEFAULT(/usr)
 -- 
 1.7.9.5
 


### PR DESCRIPTION
It shows warning when apply configure.ac-automake-error.patch:

| WARNING: mtree-1.0.3+gitAUTOINC+4f3e901aea-r0 do_patch:
| ...
| Details:
| Applying patch configure.ac-automake-error.patch
| patching file configure.ac
| Hunk #1 succeeded at 4 with fuzz 2 (offset -2 lines).

Update context of configure.ac-automake-error.patch to sync with current
mtree source codes.

Signed-off-by: Kai Kang <kai.kang@windriver.com>