### PR TITLE
meta-efi-secure-boot: Ensure openssl-native exists when we need it

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi_2.02.bbappend
@@ -1,3 +1,4 @@
+DEPENDS += "openssl-native"
 FILESEXTRAPATHS_prepend := "${THISDIR}/grub-efi:"
 
 EXTRA_SRC_URI = "\
@@ -123,7 +124,7 @@ fakeroot python do_sign_class-target() {
         uks_sel_sign(dir + 'password.inc', d)
 }
 
-fakeroot python do_sign() {
+python do_sign() {
 }
 addtask sign after do_install before do_deploy do_package
 do_sign[prefuncs] += "check_deploy_keys"

--- a/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
@@ -21,7 +21,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d9bf404642f21afb4ad89f95d7bc91ee"
 
 DEPENDS += "\
-    gnu-efi sbsigntool-native \
+    gnu-efi sbsigntool-native openssl-native \
 "
 
 PV = "0.4.6+git${SRCPV}"

--- a/meta-efi-secure-boot/recipes-core/images/kernel-initramfs.bbappend
+++ b/meta-efi-secure-boot/recipes-core/images/kernel-initramfs.bbappend
@@ -1,3 +1,4 @@
+DEPENDS += "openssl-native"
 inherit user-key-store deploy
 
 # Always fetch the latest initramfs image

--- a/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
@@ -1,3 +1,4 @@
+DEPENDS += "openssl-native"
 FILESEXTRAPATHS_prepend := "${THISDIR}/linux-yocto:"
 
 efi_secure_boot_sccs = "\


### PR DESCRIPTION
In order to deploy our secure boot keys in DER format we need to use
openssl.  This must be listed in our DEPENDS line in order for the
sysroot to be populated correctly when we run do_sign.  Also drop the
explicit fakeroot on our empty grub-efi do_sign as we may not have
globally populated virtual/fakeroot-native at that point in time.

Fixes: 92316d4b402b ("meta-signing-key: When deploying keys UEFI keys, deploy DER format")
Signed-off-by: Tom Rini <trini@konsulko.com>