### PR TITLE
Bump tpm2-abrmd from 2.0.1 to 2.0.3 to fix build with musl

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.0.3.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.0.3.bb
@@ -4,5 +4,5 @@ SRC_URI += " \
     https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz \
     file://tpm2-abrmd.default \
 "
-SRC_URI[md5sum] = "533bb7b16e9335c32f67e80961542e19"
-SRC_URI[sha256sum] = "b012a6c3e4462a411eaafd3dc8d3b13ef4118348acfd5108b68a57c8c0a5ed9c"
+SRC_URI[md5sum] = "a71faf008de2e444265b0d1d889cab2e"
+SRC_URI[sha256sum] = "ff0ed283b0300cd784d6bf2b042e167020f8443602974e53b924e9fd98a4b515"


### PR DESCRIPTION
Several bug fixes were merged in 2.0.1 and 2.0.3, including the
following PRs that fix building tpm2-abrmd with the musl C library:

https://github.com/tpm2-software/tpm2-abrmd/pull/502
https://github.com/tpm2-software/tpm2-abrmd/pull/503

Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>