### PR TITLE
Patch ima-evm-utils to fix build with musl

### DIFF
--- a/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils/0001-ima-evm-utils-include-sys-types.h-in-header-to-fix-b.patch
+++ b/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils/0001-ima-evm-utils-include-sys-types.h-in-header-to-fix-b.patch
@@ -1,0 +1,37 @@
+From d6d021947a0e5ceeca182e8716b51eb8e02c0744 Mon Sep 17 00:00:00 2001
+From: Luca Boccassi <luca.boccassi@microsoft.com>
+Date: Tue, 26 Feb 2019 14:57:10 +0000
+Subject: [PATCH] Include sys/types.h in header to fix build with musl
+
+Building a third program that depends on libimaevm with musl fails, as
+the imaevm.h uses uid_t and gid_t without including sys/types.h:
+
+<..>/sysroot/usr/include/imaevm.h:90:2: error: unknown type name 'uid_t'
+  uid_t uid;
+
+Including sys/types.h fixes building with musl and does not affect
+building with glibc.
+
+Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>
+---
+Applied-Upstream: no
+Forwarded: https://patchwork.kernel.org/patch/10830643/
+
+ src/imaevm.h | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/src/imaevm.h b/src/imaevm.h
+index 795966a..d85db0d 100644
+--- a/src/imaevm.h
++++ b/src/imaevm.h
+@@ -44,6 +44,7 @@
+ #include <linux/fs.h>
+ #include <stdint.h>
+ #include <syslog.h>
++#include <sys/types.h>
+ #include <stdbool.h>
+ #include <errno.h>
+ 
+-- 
+2.20.1
+

--- a/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_git.bb
+++ b/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_git.bb
@@ -10,6 +10,7 @@ SRC_URI = "\
     file://0001-Don-t-build-man-pages.patch \
     file://0001-Install-evmctl-to-sbindir-rather-than-bindir.patch \
     file://Fix-the-build-failure-with-openssl-1.1.x.patch \
+    file://0001-ima-evm-utils-include-sys-types.h-in-header-to-fix-b.patch \
 "
 SRCREV = "3e2a67bdb0673581a97506262e62db098efef6d7"
 


### PR DESCRIPTION
Third party programs including libimaevm fails to build with musl
due to a missing include in the public header. Add it.
The build with glibc is unaffected. Patch sent upstream.

Signed-off-by: Luca Boccassi <luca.boccassi@microsoft.com>