### PR TITLE
kernel-initramfs: do_install depends initramfs's do_image_cpio rather…

### DIFF
--- a/meta/recipes-core/images/kernel-initramfs.bb
+++ b/meta/recipes-core/images/kernel-initramfs.bb
@@ -26,7 +26,7 @@ BUNDLE = "${@'1' if d.getVar('INITRAMFS_IMAGE', True) and \
 python() {
     image = d.getVar('INITRAMFS_IMAGE', True)
     if image:
-        d.appendVarFlag('do_install', 'depends', ' ${INITRAMFS_IMAGE}:do_rootfs')
+        d.appendVarFlag('do_install', 'depends', ' ${INITRAMFS_IMAGE}:do_image_cpio')
 }
 
 do_unpack[depends] += "virtual/kernel:do_deploy"


### PR DESCRIPTION
… than do_rootfs

...
|install: cannot stat 'tmp-glibc/deploy/images/intel-x86-64/secure-core-image-init
ramfs-intel-x86-64.cpio.gz': No such file or directory
...

The cpio.gz image required by do_install is generated in do_image_cpio
rather than do_rootfs

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>