### PR TITLE
kernel-initramfs: depends on do_image_complete rather than do_rootfs

### DIFF
--- a/meta/recipes-core/images/kernel-initramfs.bb
+++ b/meta/recipes-core/images/kernel-initramfs.bb
@@ -26,7 +26,7 @@ BUNDLE = "${@'1' if d.getVar('INITRAMFS_IMAGE', True) and \
 python() {
     image = d.getVar('INITRAMFS_IMAGE', True)
     if image:
-        d.appendVarFlag('do_install', 'depends', ' ${INITRAMFS_IMAGE}:do_rootfs')
+        d.appendVarFlag('do_install', 'depends', ' ${INITRAMFS_IMAGE}:do_image_complete')
 }
 
 do_unpack[depends] += "virtual/kernel:do_deploy"


### PR DESCRIPTION
...
|install: cannot stat 'tmp-glibc/deploy/images/intel-x86-64/secure-core-image-init
ramfs-intel-x86-64.cpio.gz': No such file or directory
...

Depends do_image_complete after required image generated

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>