### PR TITLE
meta-integrity/conf/layer.conf: add opemembedded-layer as layer depen…

### DIFF
--- a/meta-integrity/conf/layer.conf
+++ b/meta-integrity/conf/layer.conf
@@ -16,6 +16,7 @@ BBLAYERS_LAYERINDEX_NAME_integrity = "meta-integrity"
 LAYERDEPENDS_integrity = "\
     core \
     signing-key \
+    openembedded-layer \
 "
 
 LAYERRECOMMENDS_integrity = "\


### PR DESCRIPTION
…dency

Fix ima-inspect build failure:

$ bitbake ima-inspect
ERROR: Nothing PROVIDES 'tclap' (but
/build/poky/meta-secure-core/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.11.bb
DEPENDS on or otherwise requires it).
ERROR: Required build target 'ima-inspect' has no buildable providers.
Missing or unbuildable dependency chain was: ['ima-inspect', 'tclap']

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>