### PR TITLE
tpm2-tss: fix do_compile error

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss/0001-build-update-for-ax_code_coverage.m4-version-2019.01.patch
+++ b/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss/0001-build-update-for-ax_code_coverage.m4-version-2019.01.patch
@@ -1,0 +1,49 @@
+From 91d71fb0b7316dedc18ab003954b2358008d8cde Mon Sep 17 00:00:00 2001
+From: Jonas Witschel <diabonas@gmx.de>
+Date: Mon, 7 Jan 2019 22:15:06 +0100
+Subject: [PATCH] build: update for ax_code_coverage.m4 version 2019.01.06
+
+ @CODE_COVERAGE_RULES@ doesn't exist any more and needs to be replaced.
+ Also includes a compatibility switch for older versions of the file.
+
+Upstream-Status: Backport [https://github.com/tpm2-software/tpm2-tss/commit/648fa841fa2f2bb6f8fdda02c36ac0abb45f5329]
+
+Signed-off-by: Jonas Witschel <diabonas@gmx.de>
+Signed-off-by: Mingli Yu <Mingli.Yu@windriver.com>
+---
+ Makefile.am  | 6 ++++++
+ configure.ac | 3 +++
+ 2 files changed, 9 insertions(+)
+
+diff --git a/Makefile.am b/Makefile.am
+index d78d23f..7815c4b 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -42,7 +42,13 @@ noinst_PROGRAMS =
+ 
+ ### Add ax_* rules ###
+ # ax_code_coverage
++if AUTOCONF_CODE_COVERAGE_2019_01_06
++include $(top_srcdir)/aminclude_static.am
++clean-local: code-coverage-clean
++dist-clean-local: code-coverage-dist-clean
++else
+ @CODE_COVERAGE_RULES@
++endif
+ 
+ # ax_doxygen
+ @DX_RULES@
+diff --git a/configure.ac b/configure.ac
+index c8aa314..40883a8 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -206,6 +206,9 @@ DX_INIT_DOXYGEN($PACKAGE_NAME, [Doxyfile], [doc/doxygen])
+ AM_CONDITIONAL(DOXYMAN, [test $DX_FLAG_man -eq 1])
+ 
+ AX_CODE_COVERAGE
++m4_ifdef([_AX_CODE_COVERAGE_RULES],
++         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [true])],
++         [AM_CONDITIONAL(AUTOCONF_CODE_COVERAGE_2019_01_06, [false])])
+ 
+ AC_OUTPUT
+ 

--- a/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_2.0.0.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_2.0.0.bb
@@ -1,6 +1,9 @@
 include ${BPN}.inc
 
-SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz"
+SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz \
+           file://0001-build-update-for-ax_code_coverage.m4-version-2019.01.patch \
+"
+
 SRC_URI[md5sum] = "048ea77be36f881b7b6ecefbc1cf7dbd"
 SRC_URI[sha256sum] = "7dfd05f7d2c4d5339d1c9ecbdba25f4ea6df70e96b09928e15e0560cce02d525"
 


### PR DESCRIPTION
After commit [5ef547b autoconf-archive: update to 2019.01.06]
applied in oe-core, there comes below error
when build tpm2-tss:
| NOTE: make -j 48
| Makefile:14636: *** missing separator.  Stop.

So backport a patch from tpm2-tss upstream to fix
this failure.

Signed-off-by: Mingli Yu <Mingli.Yu@windriver.com>