### PR TITLE
meta-secure-core: use bb.fatal instead of bb.build.FuncFailed

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -29,8 +29,7 @@ python check_rpm_public_key () {
             (gpg_bin, gpg_path, d.getVar('RPM_GPG_PASSPHRASE', True), gpg_key)
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
-        raise bb.build.FuncFailed('Failed to import gpg key (%s): %s' %
-                                  (gpg_key, output))
+        bb.fatal('Failed to import gpg key (%s): %s' % (gpg_key, output))
 }
 check_rpm_public_key[lockfiles] = "${TMPDIR}/check_rpm_public_key.lock"
 do_package_write_rpm[prefuncs] += "check_rpm_public_key"
@@ -46,6 +45,5 @@ python () {
     if not os.path.exists(gpg_path):
         status, output = oe.utils.getstatusoutput('mkdir -m 0700 -p %s' % gpg_path)
         if status:
-            raise bb.build.FuncFailed('Failed to create gpg keying %s: %s' %
-                                      (gpg_path, output))
+            bb.fatal('Failed to create gpg keying %s: %s' % (gpg_path, output))
 }

--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -53,7 +53,7 @@ def sign_efi_image(key, cert, input, output, d):
     try:
         result, _ = bb.process.run(cmd)
     except bb.process.ExecutionError:
-        raise bb.build.FuncFailed('ERROR: Unable to sign %s' % input)
+        bb.fatal('Unable to sign %s' % input)
 
 def edss_sign_efi_image(input, output, d):
    # This function will be overloaded in pulsar-binary-release
@@ -136,7 +136,7 @@ def sel_sign(key, cert, input, d):
     try:
         result, _ = bb.process.run(cmd)
     except bb.process.ExecutionError:
-        raise bb.build.FuncFailed('ERROR: Unable to sign %s' % input)
+        bb.fatal('Unable to sign %s' % input)
 
 def uks_sel_sign(input, d):
     if d.getVar('UEFI_SB', True) != '1':
@@ -220,7 +220,7 @@ def pem2der(input, output, d):
     try:
         result, _ = bb.process.run(cmd)
     except bb.process.ExecutionError:
-        raise bb.build.FuncFailed('ERROR: Unable to convert %s to %s' % (input, output))
+        raise bb.fatal('Unable to convert %s to %s' % (input, output))
 
 # Convert the certificate (PEM formatted) to ESL.
 __pem2esl() {
@@ -429,7 +429,7 @@ def sanity_check_user_keys(name, may_exit, d):
 
     if _ == False:
         if may_exit:
-            raise bb.build.FuncFailed('ERROR: Unable to find user key for %s ...' % name)
+            bb.fatal('Unable to find user key for %s ...' % name)
 
         vprint('Failed to check the user keys for %s ...' % name, d)
 


### PR DESCRIPTION
The bb.build.FuncFailed had been removed in bitbake with commit
cfeffb602dd5319f071cd6bcf84139ec77f2d170. Use bb.fatal instead of it.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>