### PR TITLE
grub-efi: fix uid contamination by host QA warning

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -129,6 +129,16 @@ python do_sign() {
 addtask sign after do_install before do_deploy do_package
 do_sign[prefuncs] += "check_deploy_keys"
 
+fakeroot do_chownp7b() {
+    chown root:root -R "${D}${EFI_BOOT_PATH}/grub.cfg.p7b"
+    chown root:root -R "${D}${EFI_BOOT_PATH}/boot-menu.inc.p7b"
+    [ x"${UEFI_SB}" = x"1" ] && {
+        chown root:root -R "${D}${EFI_BOOT_PATH}/efi-secure-boot.inc.p7b"
+        chown root:root -R "${D}${EFI_BOOT_PATH}/password.inc.p7b"
+    }
+}
+addtask chownp7b after do_deploy before do_package
+
 # Override the do_deploy() in oe-core.
 do_deploy_class-target() {
     install -m 0644 "${D}${EFI_BOOT_PATH}/${GRUB_IMAGE}" "${DEPLOYDIR}"


### PR DESCRIPTION
Fix the following QA issue:
WARNING: grub-efi-2.04-r0 do_package_qa: QA Issue: grub-efi: /boot/efi/EFI/BOOT/grub.cfg.p7b is owned by uid 19183

chown to root for p7b file to fix uid contamination by host.

Signed-off-by: Liwei Song <liwei.song@windriver.com>