### PR TITLE
secure-core:allow other layer overwrite INITRAMFS_IMAGE

### DIFF
--- a/meta/recipes-core/images/secure-core-image.inc
+++ b/meta/recipes-core/images/secure-core-image.inc
@@ -25,7 +25,7 @@ IMAGE_INSTALL = "\
 
 IMAGE_LINGUAS = " "
 
-INITRAMFS_IMAGE = "secure-core-image-initramfs"
+INITRAMFS_IMAGE ?= "secure-core-image-initramfs"
 
 inherit core-image
 


### PR DESCRIPTION
Allow other layer overwrite $INITRAMFS_IMAGE.

Signed-off-by: Jiang Lu <lu.jiang@windriver.com>
Signed-off-by: Liwei Song <liwei.song@windriver.com>