### PR TITLE
Security: do not install private keys into rootfs

### DIFF
--- a/meta-integrity/README.md
+++ b/meta-integrity/README.md
@@ -110,14 +110,15 @@ default, the sample keys are used for the purpose of development and
 demonstration. Please ensure you know what your risk is to use the sample keys
 in your product, because they are completely public.
 
-If sample keys are used, the private IMA key is installed as /etc/keys/x509_ima.key.
+Private keys are not installed into the target image. If you understand your
+risks, you can copy them to your target file system or to an external storage.
 
-A typical signing command is as following:
+If you do so, a typical signing command is as following:
 
-    # evmctl ima_sign --hashalgo sha256 --key /etc/keys/x509_ima.key --pass=<passowrd> /path/to/file
+    # evmctl ima_sign --hashalgo sha256 --key path/to/x509_ima.key --pass=<passowrd> /path/to/file
 or
 
-    # evmctl ima_sign --hashalgo sha256 --key /etc/keys/x509_ima.key --pass=<passowrd> -r /path/to/directory
+    # evmctl ima_sign --hashalgo sha256 --key /path/to/x509_ima.key --pass=<passowrd> -r /path/to/directory
 
 The following command can be used to verify a file's IMA signature with specified certificate:
 

--- a/meta-integrity/recipes-base/packagegroups/packagegroup-ima.bb
+++ b/meta-integrity/recipes-base/packagegroups/packagegroup-ima.bb
@@ -15,6 +15,6 @@ RDEPENDS_${PN} += "\
 
 # Note any private key is not available if user key signing model used.
 RRECOMMENDS_${PN} += "\
-    key-store-ima-privkey \
-    key-store-system-trusted-privkey \
+    key-store-ima-cert \
+    key-store-system-trusted-cert \
 "

--- a/meta-integrity/recipes-kernel/linux/linux-yocto-integrity.inc
+++ b/meta-integrity/recipes-kernel/linux/linux-yocto-integrity.inc
@@ -17,9 +17,11 @@ SRC_URI += "\
 
 INHIBIT_PACKAGE_STRIP = "${@'1' if d.getVar('MODSIGN_ENABLED', True) == '1' else '0'}"
 
+inherit ${@'user-key-store' if d.getVar('MODSIGN_ENABLED', True) == '1' else ''}
+
 do_configure_prepend() {
     sys_cert="${STAGING_DIR_TARGET}${sysconfdir}/keys/system_trusted_key.crt"
-    modsign_key="${STAGING_DIR_TARGET}${sysconfdir}/keys/modsign_key.key"
+    modsign_key="${@uks_modsign_keys_dir(d)}/modsign_key.key"
     modsign_cert="${STAGING_DIR_TARGET}${sysconfdir}/keys/modsign_key.crt"
 
     if [ -f "$sys_cert" ]; then

--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -14,18 +14,6 @@ KEY_DIR = "${sysconfdir}/keys"
 # For RPM verification
 RPM_KEY_DIR = "${sysconfdir}/pki/rpm-gpg"
 
-# For ${PN}-system-trusted-privkey
-SYSTEM_PRIV_KEY = "${KEY_DIR}/system_trusted_key.key"
-
-# For ${PN}-secondary-trusted-privkey
-SECONDARY_TRUSTED_PRIV_KEY = "${KEY_DIR}/secondary_trusted_key.key"
-
-# For ${PN}-modsign-privkey
-MODSIGN_PRIV_KEY = "${KEY_DIR}/modsign_key.key"
-
-# For ${PN}-ima-privkey
-IMA_PRIV_KEY = "${KEY_DIR}/x509_ima.key"
-
 # For ${PN}-system-trusted-cert
 SYSTEM_CERT = "${KEY_DIR}/system_trusted_key.crt"
 
@@ -42,26 +30,6 @@ IMA_CERT = "${KEY_DIR}/x509_ima.der"
 python () {
     if not (uks_signing_model(d) in "sample", "user"):
         return
-
-    pn = d.getVar('PN', True) + '-system-trusted-privkey'
-    d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar('SYSTEM_PRIV_KEY', True))
-    d.setVar('CONFFILES_' + pn, d.getVar('SYSTEM_PRIV_KEY', True))
-
-    pn = d.getVar('PN', True) + '-secondary-trusted-privkey'
-    d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar('SECONDARY_TRUSTED_PRIV_KEY', True))
-    d.setVar('CONFFILES_' + pn, d.getVar('SECONDARY_TRUSTED_PRIV_KEY', True))
-
-    pn = d.getVar('PN', True) + '-modsign-privkey'
-    d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar('MODSIGN_PRIV_KEY', True))
-    d.setVar('CONFFILES_' + pn, d.getVar('MODSIGN_PRIV_KEY', True))
-
-    pn = d.getVar('PN', True) + '-ima-privkey'
-    d.setVar('PACKAGES_prepend', pn + ' ')
-    d.setVar('FILES_' + pn, d.getVar('IMA_PRIV_KEY', True))
-    d.setVar('CONFFILES_' + pn, d.getVar('IMA_PRIV_KEY', True))
 
     pn = d.getVar('PN', True) + '-rpm-pubkey'
     d.setVar('PACKAGES_prepend', pn + ' ')
@@ -93,36 +61,18 @@ do_install() {
     key_dir="${@uks_system_trusted_keys_dir(d)}"
     install -m 0644 "$key_dir/system_trusted_key.crt" "${D}${SYSTEM_CERT}"
 
-    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
-        install -m 0400 "$key_dir/system_trusted_key.key" "${D}${SYSTEM_PRIV_KEY}"
-    fi
-
     key_dir="${@uks_secondary_trusted_keys_dir(d)}"
     install -m 0644 "$key_dir/secondary_trusted_key.crt" \
         "${D}${SECONDARY_TRUSTED_CERT}"
     openssl x509 -inform PEM -outform DER -in "${D}${SECONDARY_TRUSTED_CERT}" \
         -out "${D}${SECONDARY_TRUSTED_DER_ENC_CERT}"
 
-    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
-        install -m 0400 "$key_dir/secondary_trusted_key.key" \
-            "${D}${SECONDARY_TRUSTED_PRIV_KEY}"
-    fi
-
     key_dir="${@uks_modsign_keys_dir(d)}"
     install -m 0644 "$key_dir/modsign_key.crt" \
         "${D}${MODSIGN_CERT}"
 
-    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
-        install -m 0400 "$key_dir/modsign_key.key" \
-            "${D}${MODSIGN_PRIV_KEY}"
-    fi
-
     key_dir="${@uks_ima_keys_dir(d)}"
     install -m 0644 "$key_dir/x509_ima.der" "${D}${IMA_CERT}"
-
-    if [ "${@uks_signing_model(d)}" = "sample" -o "${@uks_signing_model(d)}" = "user" ]; then
-        install -m 0400 "$key_dir/x509_ima.key" "${D}${IMA_PRIV_KEY}"
-    fi
 }
 
 do_install[prefuncs] += "check_deploy_keys"
@@ -158,10 +108,6 @@ PACKAGES = "\
 
 # Note any private key is not available if user key signing model used.
 PACKAGES_DYNAMIC = "\
-    ${PN}-system-trusted-privkey \
-    ${PN}-secondary-trusted-privkey \
-    ${PN}-modsign-privkey \
-    ${PN}-ima-privkey \
     ${PN}-rpm-pubkey \
 "
 


### PR DESCRIPTION
Currently `packagegroup-ima` would pull **private keys** into rootfs. Fix this behaviour and stop one to ever pulling private keys into rootfs by dropping `key-store-*-privkey` packages. There is no reason to have them at all.