### PR TITLE
linux-yocto-integrity.inc: fix 'uks_modsign_keys_dir' is not defined

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-yocto-integrity.inc
+++ b/meta-integrity/recipes-kernel/linux/linux-yocto-integrity.inc
@@ -17,11 +17,15 @@ SRC_URI += "\
 
 INHIBIT_PACKAGE_STRIP = "${@'1' if d.getVar('MODSIGN_ENABLED', True) == '1' else '0'}"
 
-inherit ${@'user-key-store' if d.getVar('MODSIGN_ENABLED', True) == '1' else ''}
+inherit user-key-store
 
 do_configure_prepend() {
     sys_cert="${STAGING_DIR_TARGET}${sysconfdir}/keys/system_trusted_key.crt"
-    modsign_key="${@uks_modsign_keys_dir(d)}/modsign_key.key"
+    if [ ${MODSIGN_ENABLED} = "1" ]; then
+        modsign_key="${@uks_modsign_keys_dir(d)}/modsign_key.key"
+    else
+        modsign_key="${STAGING_DIR_TARGET}${sysconfdir}/keys/modsign_key.key"
+    fi
     modsign_cert="${STAGING_DIR_TARGET}${sysconfdir}/keys/modsign_key.crt"
 
     if [ -f "$sys_cert" ]; then


### PR DESCRIPTION
Since commit [b41010c linux-yocto-integrity: fix modsign key path] applied,
if MODSIGN_ENABLED is "0", bbclass user-key-store will not be inherited
which causing 'uks_modsign_keys_dir' is not defined

Unconditionally inherit user-key-store, but conditionally invoke
uks_modsign_keys_dir

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>