### PR TITLE
lib-evm-utils: using the correct algo for v2 signature

### DIFF
--- a/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils/0001-libimaevm-retrieve-correct-algo-for-v2-signature.patch
+++ b/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils/0001-libimaevm-retrieve-correct-algo-for-v2-signature.patch
@@ -1,0 +1,26 @@
+From c740d114ca213ece820da39ce2ce99fc4d6ae5c7 Mon Sep 17 00:00:00 2001
+From: Yunguo Wei <yunguo.wei@windriver.com>
+Date: Thu, 10 Oct 2019 16:40:21 +0800
+Subject: [PATCH] libimaevm: retrieve correct algo for v2 signature
+
+Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>
+---
+ src/libimaevm.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/libimaevm.c b/src/libimaevm.c
+index 7c17bf4..3586e02 100644
+--- a/src/libimaevm.c
++++ b/src/libimaevm.c
+@@ -939,7 +939,7 @@ static int sign_hash_v2(const char *algo, const unsigned char *hash,
+ 	if (!EVP_PKEY_sign_init(ctx))
+ 		goto err;
+ 	st = "EVP_get_digestbyname";
+-	if (!(md = EVP_get_digestbyname(imaevm_params.hash_algo)))
++	if (!(md = EVP_get_digestbyname(algo)))
+ 		goto err;
+ 	st = "EVP_PKEY_CTX_set_signature_md";
+ 	if (!EVP_PKEY_CTX_set_signature_md(ctx, md))
+-- 
+2.7.4
+

--- a/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_git.bb
+++ b/meta-integrity/recipes-support/ima-evm-utils/ima-evm-utils_git.bb
@@ -10,6 +10,7 @@ SRC_URI = "\
     file://0001-Don-t-build-man-pages.patch \
     file://0001-Install-evmctl-to-sbindir-rather-than-bindir.patch \
     file://0001-ima-evm-utils-include-sys-types.h-in-header-to-fix-b.patch \
+    file://0001-libimaevm-retrieve-correct-algo-for-v2-signature.patch \
 "
 SRCREV = "3eab1f93b634249c1720f65fcb495b1996f0256e"
 


### PR DESCRIPTION
When using rpmsign (with --signfiles --fskpath) to sign RPM package,
the IMA signature is not correct, see:

$ getfattr -d -m - rootfs/usr/sbin/grpconv

file: rootfs/usr/sbin/grpconv
security.ima=0sAwIEDy1SEQP3AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA==

And the expected signature is like this:
$ getfattr -d -m - rootfs/usr/sbin/grpconv

file: rootfs/usr/sbin/grpconv
security.ima=0sAwIEDy1SEQEAA6s8DwmRCVutcrE8NvHWWYXlg8L1AwH5teu44prkKRwmhZQ52Oa4UQoZZlxER/SJ9tijbve8ZAv++KW8EqgP4iZjEGh8ke76rpiRU5glnG/U+HUjnilJBpzpMJHxyNbAiFoHMESeCOtrhY0zZIUXK3DnIuIJSwpfl2HaNFxRrE38EaqgV9IQ8QiWFCvgDYXoJDwc3KdhjKjs214tCfZpKO1w4QJl2n4llZHw2RTHIuUOsMhRDEXs6onLHmdmhvqgxIHt7IvsT9v7H8GnoaiX0xgzxk2o/mE5EtPrnMtUoGSQwdY8CAfUbCwAp0c5QlsrHk5RBmewjJ/jxd/K1uKp7w==

The root cause is libimaevm doesn't retrieve correct signing algo, so this patch
is making things right.

Signed-off-by: Yunguo Wei <yunguo.wei@windriver.com>