### PR TITLE
grub-efi/boot-menu.inc: remove invalid menuentry

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/boot-menu.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/boot-menu.inc
@@ -8,8 +8,3 @@ menuentry "Sample EFI boot" --unrestricted {
     linux /bzImage root=/dev/hda2 ro rootwait
     initrd /initrd
 }
-
-menuentry "Sample EFI boot (Recovery)" --unrestricted {
-    linux /bzImage_backup root=/dev/hda2 ro rootwait
-    initrd /initrd_backup
-}


### PR DESCRIPTION
Currently the recovery menuentry is not available because we don't
provide bzImage_backup and initrd_backup. Remove this entry.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>