### PR TITLE
sign_rpm_ext.bbclass: fix compile fail since missing gpg

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -10,6 +10,9 @@ RPM_FSK_PASSWORD ?= "password"
 
 inherit sign_rpm user-key-store
 
+GPG_DEP = "${@'' if d.getVar('GPG_BIN')  else 'gnupg-native pinentry-native'}"
+DEPENDS_append_class-target += "${GPG_DEP}"
+
 python check_rpm_public_key () {
     gpg_path = d.getVar('GPG_PATH', True)
     gpg_bin = d.getVar('GPG_BIN', True) or \


### PR DESCRIPTION
there is a scenario that this bbclass is enabled globally,
all targets will inherit sign_rpm_ext. but this bbclass
need gpg to work, on some new distro like
ubuntun 19.04, gpg is not installed, so compile will failed.

fail cmd:
cmd = '%s --batch --homedir %s --passphrase %s --import %s' % \
            (gpg_bin, gpg_path, d.getVar('RPM_GPG_PASSPHRASE', True), gpg_key)
error:
base-files-3.0.14-r89 do_package_write_rpm: Failed to import gpg key (): /bin/sh: 1: --batch: not found

Signed-off-by: Changqing Li <changqing.li@windriver.com>