### PR TITLE
kernel-initramfs-efi-secure-boot.inc: Copy .sig files and .p7b

### DIFF
--- a/meta-efi-secure-boot/recipes-core/images/kernel-initramfs-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-core/images/kernel-initramfs-efi-secure-boot.inc
@@ -17,11 +17,9 @@ do_sign[prefuncs] += "${@'check_boot_public_key' if d.getVar('GRUB_SIGN_VERIFY',
 
 do_deploy() {
     install -d "${DEPLOYDIR}"
-    if [ "${UEFI_SELOADER}" = "1" ] ; then
-        for SIG in ${D}/boot/*${SB_FILE_EXT}; do
-            install -m 0644 ${SIG} ${DEPLOYDIR}
-        done
-    fi
+    for SIG in ${D}/boot/*${SB_FILE_EXT}; do
+        install -m 0644 ${SIG} ${DEPLOYDIR}
+    done
 }
 addtask deploy after do_install before do_build
 


### PR DESCRIPTION
While refactoring the code to eliminate the overlap in the copy of the
.sig and .p7b files the UEFI_SELOADER test was not removed.  This
results in the .sig files not getting copied to the deploy directory
when using the GRUB_SIGN_VERIFY = "1".

All that is needed is to remove the UEFI_SELOADER test statement.

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>