### PR TITLE
Misc fixes missing from master branch

### DIFF
--- a/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
+++ b/meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend
@@ -1,2 +1,2 @@
 RDEPENDS_${PN} += "lvm2"
-RRECOMMENDS_${PN} += "lvm2-udevrules"
+RRECOMMENDS_${PN}_append_class-target = " lvm2-udevrules"

--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -60,7 +60,7 @@ do_configure() {
 
     if [ ! -e lib/ccan ]; then
         export CC="${BUILD_CC}"
-        lib/ccan.git/tools/create-ccan-tree \
+        TMPDIR=lib lib/ccan.git/tools/create-ccan-tree \
             --build-type=automake lib/ccan \
                 talloc read_write_all build_assert array_size endian || exit 1
     fi


### PR DESCRIPTION
Joe Slater (1):
      sbsigntool-native: specify TMPDIR

Robert Yang (1):
      cryptsetup_%.bbappend: Fix for native

 meta-encrypted-storage/recipes-support/cryptsetup/cryptsetup_%.bbappend | 2 +-
 meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb          | 2 +-
 2 files changed, 2 insertions(+), 2 deletions(-)
