### PR TITLE
efitools-native: Fix compilation problem with latest /usr/include/efi

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -29,6 +29,7 @@ SRC_URI = "\
     file://Reuse-xxdi.pl.patch \
     file://Add-static-keyword-for-IsValidVariableHeader.patch \
     file://Dynamically-load-openssl.cnf-for-openssl-1.0.x-and-1.patch \
+    file://0001-console.c-Fix-compilation-against-latest-usr-include.patch \
 "
 SRCREV = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
 

--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools_git.bb
@@ -10,7 +10,6 @@ SRC_URI_append += "\
     file://Build-DBX-by-default.patch \
     file://LockDown-disable-the-entrance-into-BIOS-setup-to-re-.patch \
     file://Fix-help2man-error.patch \
-    file://0001-console.c-Fix-compilation-against-latest-usr-include.patch \
 "
 
 COMPATIBLE_HOST = '(i.86|x86_64).*-linux'


### PR DESCRIPTION
Since commit [382ffa1 efitools: Fix compilation problem with
latest /usr/include/efi], we should apply the fix to native also.

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>