### PR TITLE
efitools: do not do_sign if GRUB_SIGN_VERIFY not enabled

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -61,6 +61,9 @@ do_install() {
 }
 
 fakeroot python do_sign_class-target() {
+    if d.getVar('GRUB_SIGN_VERIFY', True) != '1':
+        return
+
     image_dir = d.getVar('D', True)
     efi_boot_path = d.getVar('EFI_BOOT_PATH', True)
     uks_boot_sign(os.path.join(image_dir + efi_boot_path, 'LockDown.efi'), d)


### PR DESCRIPTION
If GRUB_SIGN_VERIFY is not enabled, do_sign will fail in which GPG_PATH
is not set (--homedir None)
...
|DEBUG: Executing python function do_sign
|NOTE: Running: echo "SecureCore" | tmp-glibc/hosttools/gpg  --pinentry-mode
loopback --batch --homedir None -u "SecureBootCore" --detach-sign
--passphrase-fd 0 "tmp-glibc/work/core2-32-wrs-linux/efitools/
1.9.2+gitAUTOINC+392836a46c-r0/image/boot/efi/EFI/BOOT/LockDown.efi"
|ERROR: Failed to sign: tmp-glibc/work/core2-32-wrs-linux/efitools/
1.9.2+gitAUTOINC+392836a46c-r0/image/boot/efi/EFI/BOOT/LockDown.efi
...

Since GPG_PATH is set in do_sign's prefunc check_boot_public_key if
GRUB_SIGN_VERIFY is enabled, add the same condition to do_sign

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>