### PR TITLE
rpm-integrity: Use _append for PACKAGECONFIG

### DIFF
--- a/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
+++ b/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS_prepend := "${THISDIR}/rpm:"
 
-PACKAGECONFIG = "${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'imaevm', '', d)}"
+PACKAGECONFIG_append = " \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'imaevm', '', d)} \
+    "
 
 # IMA signing support is provided by RPM plugin.
 EXTRA_OECONF_remove += "\


### PR DESCRIPTION
Currently, the PACKAGECONFIG assignment in rpm-integrity might overwrite
the previous contents of the variable.

Similar to systemd_%.bbappend and ovmf_%.bbappend, use _append to add
"imaevm" to PACKAGECONFIG when distro feature ima is enabled.

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>