### PR TITLE
user-key-store.bbclass: Depend on gnupg-native to always use provided…

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -2,7 +2,7 @@ DEPENDS_append_class-target += "\
     sbsigntool-native \
     libsign-native \
     openssl-native \
-    ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "efitools-native", "", d)} \
+    ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "efitools-native gnupg-native", "", d)} \
 "
 
 USER_KEY_SHOW_VERBOSE = "1"


### PR DESCRIPTION
… gpg

On some host configuration such as ubuntu 16.04 the gnupg in /usr/bin
is the 1.x version.  This can cause problems between the import and
signing process if the gpg version is different.  The commands in the
user-key-store class assume gnupg is at least version 2.2 or newer.

To avoid the signing phase failing for the efitools and the kernel,
the user-key-store class should depend on the gnupg-native binaries.

It avoids this specific error:

ERROR: efitools-1.9.2+gitAUTOINC+392836a46c-r0 do_sign: Failed to sign: /opt/tmp-glibc/work/corei7-64-wrs-linux/efitools/1.9.2+gitAUTOINC+392836a46c-r0/image/boot/efi/EFI/BOOT/LockDown.efi
ERROR: Logfile of failure stored in: /opt/tmp-glibc/work/corei7-64-wrs-linux/efitools/1.9.2+gitAUTOINC+392836a46c-r0/temp/log.do_sign.22969
NOTE: recipe efitools-1.9.2+gitAUTOINC+392836a46c-r0: task do_sign: Failed

[ Issue: LIN1019-3757 ]

Signed-off-by: Jason Wessel <jason.wessel@windriver.com>