### PR TITLE
tpm-tools: inherit perlnative.bbclass

### DIFF
--- a/meta-tpm/recipes-tpm/tpm-tools/tpm-tools_git.bb
+++ b/meta-tpm/recipes-tpm/tpm-tools/tpm-tools_git.bb
@@ -24,7 +24,7 @@ SRCREV = "bdf9f1bc8f63cd6fc370c2deb58d03ac55079e84"
 
 S = "${WORKDIR}/git"
 
-inherit autotools-brokensep gettext
+inherit autotools-brokensep gettext perlnative
 
 do_configure_prepend() {
     mkdir -p po


### PR DESCRIPTION
tpm-tools calls pod2man to produce manual files. But pod2man has been
removed from hosttools in oe-core. So it fails occasionally when in some
certain condition .pod file is newer than corresponding man page files
that man files need to be reproduced:

| make[3]: Entering directory 'TOPDIR/tmp-glibc/work/ppc7400-wrs-linux/tpm-tools/1.3.9.1+gitAUTOINC+bdf9f1bc8f-r0/git/man/man8'
| /bin/bash: pod2man: command not found
| make[3]: *** [Makefile:575: tpm_nvwrite.8] Error 127

Inherit perlnative to fix such issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>