### PR TITLE
initramfs: adjust task order to aviod initrd symlink unavailable

### DIFF
--- a/meta-efi-secure-boot/recipes-core/images/kernel-initramfs-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-core/images/kernel-initramfs-efi-secure-boot.inc
@@ -21,7 +21,7 @@ do_deploy() {
         install -m 0644 ${SIG} ${DEPLOYDIR}
     done
 }
-addtask deploy after do_install before do_build
+addtask deploy after do_install before do_package
 
 python do_package_prepend () {
     ext = d.expand('${SB_FILE_EXT}')


### PR DESCRIPTION
adjust task order to make sure initrd symlink is ready before
do package.

Signed-off-by: Liwei Song <liwei.song@windriver.com>