### PR TITLE
sign_rpm_ext: Use socket redirection to avoid GPG_PATH length limitation

### DIFF
--- a/meta-integrity/classes/sign_rpm_ext.bbclass
+++ b/meta-integrity/classes/sign_rpm_ext.bbclass
@@ -34,9 +34,4 @@ python () {
     if not gpg_path:
         gpg_path = d.getVar('TMPDIR', True) + '/.gnupg'
         d.setVar('GPG_PATH', gpg_path)
-
-    if len(gpg_path) > 80:
-        msg = "The default GPG_PATH {} of {} characters is too long. Due to GPG homedir path length limit, please set GPG_PATH shorter than 80 characters.".format(gpg_path, len(gpg_path))
-        raise bb.parse.SkipRecipe(msg)
-
 }

--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -481,6 +481,15 @@ def check_gpg_key(basekeyname, keydirfunc, d):
         f.write('allow-loopback-pinentry\n')
         f.write('auto-expand-secmem\n')
         f.close()
+
+        bn = d.getVar('BUILDNAME', True)
+        socklist = ["yocto-native", "browser", "ssh", "extra"]
+        for sock in socklist:
+            f = open(os.path.join(gpg_path, 'S.gpg-agent.' + sock), 'w')
+            f.write('%Assuan%\n')
+            f.write('socket=/tmp/S.gpg-agent.%s-%s\n' % (sock, bn))
+            f.close()
+
     gpg_bin = d.getVar('GPG_BIN', True) or \
               bb.utils.which(os.getenv('PATH'), 'gpg')
     gpg_keyid = d.getVar(basekeyname + '_GPG_NAME', True)
@@ -499,6 +508,8 @@ def check_gpg_key(basekeyname, keydirfunc, d):
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
         bb.fatal('Failed to import gpg key (%s): %s' % (gpg_key, output))
+
+check_gpg_key[vardepsexclude] = "BUILDNAME"
 
 python check_boot_public_key () {
     check_gpg_key('BOOT', uks_boot_keys_dir, d)


### PR DESCRIPTION
Currently, an error will be thrown when trying to use a GPG homedir whose path
length exceeds 80 characters. This limitation can be worked around by providing
libassuan socket redirection files for "S.gpg-agent.yocto-native",
"S.gpg-agent.ssh", "S.gpg-agent.browser" and "S.gpg-agent.extra"
sockets. The redirection files will point to the real sockets in /tmp
directory. The sockets will be automatically cleaned up by gpg agent.

References:
[1] https://dev.gnupg.org/T1752
[2] https://gnupg.org/documentation/manuals/assuan.pdf

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>