### PR TITLE
fixup! sign_rpm_ext: Use socket redirection to avoid GPG_PATH length …

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -482,13 +482,16 @@ def check_gpg_key(basekeyname, keydirfunc, d):
         f.write('auto-expand-secmem\n')
         f.close()
 
+    if len(gpg_path) > 80:
         bn = d.getVar('BUILDNAME', True)
-        socklist = ["yocto-native", "browser", "ssh", "extra"]
-        for sock in socklist:
-            f = open(os.path.join(gpg_path, 'S.gpg-agent.' + sock), 'w')
-            f.write('%Assuan%\n')
-            f.write('socket=/tmp/S.gpg-agent.%s-%s\n' % (sock, bn))
-            f.close()
+        suffixlist = ["yocto-native", "browser", "ssh", "extra"]
+        for suffix in suffixlist:
+            socket = os.path.join(gpg_path, 'S.gpg-agent.' + suffix)
+            if not os.path.exists(socket):
+                f = open(socket, 'w')
+                f.write('%Assuan%\n')
+                f.write('socket=/tmp/S.gpg-agent.%s-%s\n' % (suffix, bn))
+                f.close()
 
     gpg_bin = d.getVar('GPG_BIN', True) or \
               bb.utils.which(os.getenv('PATH'), 'gpg')


### PR DESCRIPTION
…limitation

If GPG_PATH is already created by signing-keys do_get_public_keys task,
subsequent executions of do_package_write_rpm will fail with "Filename too
long" errors (this only affects builds using GPG paths larger than 80
characters).

Fix this race condition by making sure that the redirection files are always
present in the gpg homedir even if the directory already exists when the first
package_write_rpm task executes.

Also, make sure this new approach does not affect GPG_PATHs smaller than 80
chars.

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>