### PR TITLE
ovmf_%.bbappend: tweak do_sign task order to avoid racing issue

### DIFF
--- a/meta-efi-secure-boot/recipes-core/ovmf/ovmf_%.bbappend
+++ b/meta-efi-secure-boot/recipes-core/ovmf/ovmf_%.bbappend
@@ -34,7 +34,7 @@ python do_sign_class-target() {
     sb_sign(d.expand('${WORKDIR}/ovmf/Hash2DxeCrypto.efi'), d.expand('${WORKDIR}/ovmf/Hash2DxeCrypto.efi.signed'), d)
     sb_sign(d.expand('${WORKDIR}/ovmf/Pkcs7VerifyDxe.efi'), d.expand('${WORKDIR}/ovmf/Pkcs7VerifyDxe.efi.signed'), d)
 }
-addtask sign after do_compile before do_install
+addtask sign after do_compile before do_install do_deploy
 
 do_deploy_class-target_append() {
     if [ x"${UEFI_SB}" = x"1" ]; then


### PR DESCRIPTION
If ovmf's do_deploy is run before do_sign, there is a failure
...
|install: cannot stat 'tmp-glibc/work/corei7-64-wrs-linux/ovmf/
edk2-stable201911-r0/ovmf/Pkcs7VerifyDxe.efi.signed': No such file or directory
...

Add do_sign before do_deploy

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>