### PR TITLE
create-user-key-store.sh: Fix defect about invalid option "--pinentry…

### DIFF
--- a/meta-signing-key/scripts/create-user-key-store.sh
+++ b/meta-signing-key/scripts/create-user-key-store.sh
@@ -340,9 +340,15 @@ EOF
 
     pinentry=""
     if [ "$gpg_ver" = "2" ] ; then
-            pinentry="--pinentry-mode=loopback"
-            echo "allow-loopback-pinentry" > $key_dir/gpg-agent.conf
+            gpg_ver_whole=`gpg --version | head -1 | awk '{ print $3 }'`
+            if [ "$gpg_ver_whole" != "2.0.22" ] ; then
+                pinentry="--pinentry-mode=loopback"
+                echo "allow-loopback-pinentry" > $key_dir/gpg-agent.conf
+            fi
             gpg-connect-agent --homedir "$key_dir" reloadagent /bye
+            if [ $? != 0 ] ; then
+                gpg-agent --homedir "$key_dir" --daemon
+            fi
     fi
     $GPG_BIN --homedir "$key_dir" --batch --yes --gen-key "$key_dir/gen_keyring"
     if [ $? != 0 ] ; then


### PR DESCRIPTION
…-mode=loopback"

The option --pinentry-mode is not supported in gpg 2.0.22 code.
so when the host gpg version is 2.0.22 the option will be removed.
Start gpg-agent daemon when gpg-connect-agent reload agent failed.
Otherwise there will be below failure message reported.
gpg: can't connect to the agent - trying fall back
gpg: can't connect to the agent: IPC connect call failed
gpg: problem with the agent: No agent running

Signed-off-by: De Huo <De.Huo@windriver.com>