### PR TITLE
Revert "Removed unneeded patch to fix compilation error in efi-tool's…

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -29,6 +29,7 @@ SRC_URI = "\
     file://Reuse-xxdi.pl.patch \
     file://Add-static-keyword-for-IsValidVariableHeader.patch \
     file://Dynamically-load-openssl.cnf-for-openssl-1.0.x-and-1.patch \
+    file://0001-console.c-Fix-compilation-against-latest-usr-include.patch \
 "
 SRCREV = "392836a46ce3c92b55dc88a1aebbcfdfc5dcddce"
 

--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-console.c-Fix-compilation-against-latest-usr-include.patch
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools/0001-console.c-Fix-compilation-against-latest-usr-include.patch
@@ -1,0 +1,39 @@
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Mon, 4 Nov 2019 12:42:49 -0800
+Subject: [PATCH] console.c: Fix compilation against latest /usr/include/efi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+| gcc  -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/git/include/ -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/x86_64 -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/protocol -O2 -g  -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check -DGNU_EFI_USE_MS_ABI -DEFI_FUNCTION_WRAPPER -mno-red-zone -DCONFIG_x86_64 -fno-toplevel-reorder -DBUILD_EFI -c console.c -o console.efi.o
+| console.c:360:5: error: ‘EFI_WARN_UNKOWN_GLYPH’ undeclared here (not in a function); did you mean ‘EFI_WARN_UNKNOWN_GLYPH’?
+|   {  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
+|      ^~~~~~~~~~~~~~~~~~~~~
+|      EFI_WARN_UNKNOWN_GLYPH
+| ../Make.rules:113: recipe for target 'console.efi.o' failed
+|
+
+
+Upstream-Status: Pending
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+---
+ lib/console.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/console.c b/lib/console.c
+index 9c10560..b932a44 100644
+--- a/lib/console.c
++++ b/lib/console.c
+@@ -357,7 +357,7 @@ static struct {
+ 	{  EFI_SECURITY_VIOLATION,     L"Security Violation"},
+ 
+ 	// warnings
+-	{  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
++	{  EFI_WARN_UNKNOWN_GLYPH,     L"Warning Unknown Glyph"},
+ 	{  EFI_WARN_DELETE_FAILURE,    L"Warning Delete Failure"},
+ 	{  EFI_WARN_WRITE_FAILURE,     L"Warning Write Failure"},
+ 	{  EFI_WARN_BUFFER_TOO_SMALL,  L"Warning Buffer Too Small"},
+-- 
+2.23.0
+

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim/0001-console.c-Fix-compilation-against-latest-usr-include.patch
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim/0001-console.c-Fix-compilation-against-latest-usr-include.patch
@@ -1,0 +1,39 @@
+From: Jason Wessel <jason.wessel@windriver.com>
+Date: Mon, 4 Nov 2019 12:42:49 -0800
+Subject: [PATCH] console.c: Fix compilation against latest /usr/include/efi
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+| gcc  -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/git/include/ -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/x86_64 -I/opt/tmp/work/x86_64-linux/efitools-native/1.9.2+gitAUTOINC+392836a46c-r0/recipe-sysroot-native/usr/include/efi/protocol -O2 -g  -fpic -Wall -fshort-wchar -fno-strict-aliasing -fno-merge-constants -fno-stack-protector -ffreestanding -fno-stack-check -DGNU_EFI_USE_MS_ABI -DEFI_FUNCTION_WRAPPER -mno-red-zone -DCONFIG_x86_64 -fno-toplevel-reorder -DBUILD_EFI -c console.c -o console.efi.o
+| console.c:360:5: error: ‘EFI_WARN_UNKOWN_GLYPH’ undeclared here (not in a function); did you mean ‘EFI_WARN_UNKNOWN_GLYPH’?
+|   {  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
+|      ^~~~~~~~~~~~~~~~~~~~~
+|      EFI_WARN_UNKNOWN_GLYPH
+| ../Make.rules:113: recipe for target 'console.efi.o' failed
+|
+
+
+Upstream-Status: Pending
+
+Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
+---
+ lib/console.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/lib/console.c b/lib/console.c
+index 9c10560..b932a44 100644
+--- a/lib/console.c
++++ b/lib/console.c
+@@ -357,7 +357,7 @@ static struct {
+ 	{  EFI_SECURITY_VIOLATION,     L"Security Violation"},
+ 
+ 	// warnings
+-	{  EFI_WARN_UNKOWN_GLYPH,      L"Warning Unknown Glyph"},
++	{  EFI_WARN_UNKNOWN_GLYPH,     L"Warning Unknown Glyph"},
+ 	{  EFI_WARN_DELETE_FAILURE,    L"Warning Delete Failure"},
+ 	{  EFI_WARN_WRITE_FAILURE,     L"Warning Write Failure"},
+ 	{  EFI_WARN_BUFFER_TOO_SMALL,  L"Warning Buffer Too Small"},
+-- 
+2.23.0
+

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -28,6 +28,7 @@ SRC_URI = "\
     file://0011-Update-verification_method-if-the-loaded-image-is-si.patch;apply=0 \
     file://0012-netboot-replace-the-depreciated-EFI_PXE_BASE_CODE.patch \
     file://0001-MokManager-Use-CompareMem-on-MokListNode.Type-instea.patch \
+    file://0001-console.c-Fix-compilation-against-latest-usr-include.patch \
 "
 SRC_URI_append_x86-64 = "\
     ${@bb.utils.contains('DISTRO_FEATURES', 'msft', \


### PR DESCRIPTION
… console.c"

The patch to fix compilation error in efi-tool's console.c is required

This reverts commit a6c3d9fcd2da0d20f2916d36557a73ad8790fd1c.

In <=gnu-efi-3.0.9 variable is named EFI_WARN_UNKOWN_GLYPH, and
in gnu-efi-3.0.11 is renamed in EFI_WARN_UNKNOWN_GLYPH. The patch is
only for users with installed >=gnu-efi-3.0.11 because is in this
version that variable has changed name from EFI_WARN_UNKOWN_GLYPH
to EFI_WARN_UNKNOWN_GLYPH. [1]

In oe-core master branch, the gnu-efi is 3.0.11, we need to add
the fix back

[1] https://bugs.gentoo.org/701152

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>