### PR TITLE
user-key-store.bbclass: Kill gpg agent daemon after gpg sign

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -536,6 +536,10 @@ def boot_sign(input, d):
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
         bb.fatal('Failed to sign: %s' % (input))
+    gpg_conf = bb.utils.which(os.getenv('PATH'), 'gpgconf')
+    cmd = 'GNUPGHOME=%s %s --kill gpg-agent' % \
+            (gpg_path, gpg_conf)
+    status, output = oe.utils.getstatusoutput(cmd)
 
 def uks_boot_sign(input, d):
     boot_sign(input, d)


### PR DESCRIPTION
The gpg-agent daemon will be triggered to run in function boot_sign,
This daemon will not exit even after building project.
So kill the gpg-agent daemon after gpg signing process
at the end of function boot_sign.

Signed-off-by: De Huo <De.Huo@windriver.com>