### PR TITLE
Revert "user-key-store.bbclass: Kill gpg agent daemon after gpg sign"

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -536,10 +536,6 @@ def boot_sign(input, d):
     status, output = oe.utils.getstatusoutput(cmd)
     if status:
         bb.fatal('Failed to sign: %s' % (input))
-    gpg_conf = bb.utils.which(os.getenv('PATH'), 'gpgconf')
-    cmd = 'GNUPGHOME=%s %s --kill gpg-agent' % \
-            (gpg_path, gpg_conf)
-    status, output = oe.utils.getstatusoutput(cmd)
 
 def uks_boot_sign(input, d):
     boot_sign(input, d)


### PR DESCRIPTION
This reverts commit fc8969af8a34ff93ede7d44a492750446154d950.

In parallel build this will led sign error because the gpg-agent
in using maybe killed in another task.

Signed-off-by: Liwei Song <liwei.song@windriver.com>