### PR TITLE
key-store: fix rdepends with multilib

### DIFF
--- a/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
+++ b/meta-signing-key/recipes-support/key-store/key-store_0.1.bb
@@ -35,7 +35,8 @@ python () {
     d.setVar('PACKAGES_prepend', pn + ' ')
     d.setVar('FILES_' + pn, d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-' + d.getVar('RPM_GPG_NAME', True))
     d.setVar('CONFFILES_' + pn, d.getVar('RPM_KEY_DIR', True) + '/RPM-GPG-KEY-' + d.getVar('RPM_GPG_NAME', True))
-    d.appendVar('RDEPENDS_' + pn, ' rpm')
+    mlprefix = d.getVar('MLPREFIX')
+    d.appendVar('RDEPENDS_' + pn, ' %srpm' % mlprefix)
 }
 
 do_install() {


### PR DESCRIPTION
It shows qa issue when multilib is enabled:

| ERROR: lib32-key-store-0.1-r0 do_package: QA Issue:
   lib32-key-store package lib32-key-store-rpm-pubkey - suspicious values 'rpm' in RDEPENDS [multilib]

Prepend MLPREFIX to runtime dependency 'rpm' to fix the issue.

Signed-off-by: Kai Kang <kai.kang@windriver.com>