### PR TITLE
tpm2-tss: support usrmerge

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_2.3.2.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tss/tpm2-tss_2.3.2.bb
@@ -20,7 +20,7 @@ inherit autotools pkgconfig systemd extrausers
 PACKAGECONFIG ??= ""
 PACKAGECONFIG[oxygen] = ",--disable-doxygen-doc, "
 
-EXTRA_OECONF += "--enable-static --with-udevrulesdir=${base_prefix}/lib/udev/rules.d/"
+EXTRA_OECONF += "--enable-static --with-udevrulesdir=${nonarch_base_libdir}/udev/rules.d/"
 EXTRA_OECONF_remove = " --disable-static"
 
 
@@ -76,6 +76,6 @@ FILES_libtss2-dev = " \
     ${libdir}/libtss2*so"
 FILES_libtss2-staticdev = "${libdir}/libtss*a"
 
-FILES_${PN} = "${libdir}/udev ${base_prefix}/lib/udev"
+FILES_${PN} = "${libdir}/udev ${nonarch_base_libdir}/udev"
 
 RDEPENDS_libtss2 = "libgcrypt"


### PR DESCRIPTION
fix do_package_qa error:
ERROR: QA Issue: tpm2-tss package is not obeying usrmerge distro feature. /lib should be relocated to /usr. [usrmerge]

Signed-off-by: Changqing Li <changqing.li@windriver.com>