### PR TITLE
tpm2-abrmd: rdepends on libtss2-tcti-device and libtss2-tcti-mssim

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.3.0.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.3.0.bb
@@ -49,6 +49,6 @@ do_install_append() {
 FILES_${PN} += "${libdir}/systemd/system-preset \
 		${datadir}/dbus-1"
 
-RDEPENDS_${PN} += "tpm2-tss"
+RDEPENDS_${PN} += "tpm2-tss libtss2-tcti-device libtss2-tcti-mssim"
 
 BBCLASSEXTEND = "native"


### PR DESCRIPTION
The tpm2-abrmd daemon needs TCTI library for TPM2 device or simulator.
But the libtss2-tcti-device and libtss2-tcti-mssim packages are not
installed by default which causes the tpm2-abrmd daemon startup failure:

systemd[1]: Starting TPM2 Access Broker and Resource Management Daemon...
tpm2-abrmd[459]: tcti_conf before: "device:/dev/tpm0"
tpm2-abrmd[459]: tcti_conf after: "device:/dev/tpm0"
tpm2-abrmd[459]: ERROR:tcti:../tpm2-tss-2.3.2/src/tss2-tcti/tctildr.c:418:Tss2_TctiLdr_Initialize_Ex() Failed to instantiate TCTI
tpm2-abrmd[459]: init_thread_func: failed to create TCTI with conf "device:/dev/tpm0"
tpm2-abrmd[459]: g_bus_unown_name: assertion 'owner_id > 0' failed

Add libtss2-tcti-device and libtss2-tcti-mssim to runtime dependencies.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>