### PR TITLE
trousers: update to latest git rev

### DIFF
--- a/meta-tpm/recipes-tpm/trousers/trousers_git.bb
+++ b/meta-tpm/recipes-tpm/trousers/trousers_git.bb
@@ -29,7 +29,7 @@ SRC_URI = "\
     file://tcsd.service \
     file://tcsd.conf \
 "
-SRCREV = "de57f069ef2297d6a6b3a0353e217a5a2f66e444"
+SRCREV = "e74dd1d96753b0538192143adf58d04fcd3b242b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Security fixes:

CVE-2020-24332
If the tcsd daemon is started with root privileges,
the creation of the system.data file is prone to symlink attacks

CVE-2020-24330
If the tcsd daemon is started with root privileges,
it fails to drop the root gid after it is no longer needed

CVE-2020-24331
If the tcsd daemon is started with root privileges,
the tss user has read and write access to the /etc/tcsd.conf file

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>