### PR TITLE
trousers: fix build failure for gcc-10

### DIFF
--- a/meta-tpm/recipes-tpm/trousers/trousers_git.bb
+++ b/meta-tpm/recipes-tpm/trousers/trousers_git.bb
@@ -38,6 +38,9 @@ inherit autotools pkgconfig useradd update-rc.d \
 
 EXTRA_OECONF="--with-gui=none"
 
+# Fix build failure for gcc-10
+CFLAGS_append = " -fcommon"
+
 PACKAGECONFIG ?= "gmp "
 PACKAGECONFIG[gmp] = "--with-gmp, --with-gmp=no, gmp"
 PACKAGECONFIG[gtk] = "--with-gui=gtk, --with-gui=none, gtk+"


### PR DESCRIPTION
gcc-10 uses '-fno-common' by default, causing build error of
multiple definition. Use '-fcommon' to fix this problem.

Signed-off-by: Chen Qi <Qi.Chen@windriver.com>