### PR TITLE
grub-efi-efi-secure-boot.inc: Adapt to potential psuedo changes

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -196,7 +196,7 @@ do_deploy_append_class-target() {
 
     install -d "${DEPLOYDIR}/efi-unsigned"
     install -m 0644 "${B}/${GRUB_IMAGE}" "${DEPLOYDIR}/efi-unsigned"
-    cp -af "${D}${EFI_BOOT_PATH}/${GRUB_TARGET}-efi" "${DEPLOYDIR}/efi-unsigned"
+    PSEUDO_DISABLED=1 cp -af "${D}${EFI_BOOT_PATH}/${GRUB_TARGET}-efi" "${DEPLOYDIR}/efi-unsigned"
 }
 
 FILES_${PN} += "${EFI_BOOT_PATH}"


### PR DESCRIPTION
If we do adopt path filtering for pseudo, we may filter out ${DEPLOY_DIR}
as not needing to be tracked for "root" permissions. but we do track
the data in ${D} though, when we copy file from ${D} to ${DEPLOY_DIR},
pseudo report a failure
...
|cp: failed to preserve ownership for 'tmp-glibc/work/corei7-64-wrs-linux/
grub-efi/2.04-r0/deploy-grub-efi/efi-unsigned/x86_64-efi/fdt.lst'
: Operation not permitted
...

Disable pseudo for the copy operation

Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>