### PR TITLE
check_gpg_key: Fix gpg-agent.conf creation race condition

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -477,7 +477,10 @@ def check_gpg_key(basekeyname, keydirfunc, d):
         status, output = oe.utils.getstatusoutput('mkdir -m 0700 -p %s' % gpg_path)
         if status:
             bb.fatal('Failed to create gpg keying %s: %s' % (gpg_path, output))
-        f = open(os.path.join(gpg_path, 'gpg-agent.conf'), 'w')
+
+    gpg_conf = os.path.join(gpg_path, 'gpg-agent.conf')
+    if not os.path.exists(gpg_conf):
+        f = open(gpg_conf, 'w')
         f.write('allow-loopback-pinentry\n')
         f.write('auto-expand-secmem\n')
         f.close()


### PR DESCRIPTION
If GPG_PATH is already created by signing-keys do_get_public_keys task,
subsequent executions of do_package_write_rpm will not create the
gpg-agent.conf file anymore.

Therefore, the spawned gpg-agent will miss important features such as
auto-expand-secmem, leading to the following intermittent build errors:
....
Subprocess output:
gpg: signing failed: Cannot allocate memory
gpg: signing failed: Cannot allocate memory
error: gpg exec failed (2)
gpg: signing failed: Cannot allocate memory
gpg: signing failed: Cannot allocate memory
error: gpg exec failed (2)
...

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>