### PR TITLE
user-key-store.bbclass: exclude ${GPG_PATH} from pseudo database

### DIFF
--- a/meta-signing-key/classes/user-key-store.bbclass
+++ b/meta-signing-key/classes/user-key-store.bbclass
@@ -5,6 +5,7 @@ DEPENDS_append_class-target += "\
     ${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "efitools-native gnupg-native", "", d)} \
 "
 
+PSEUDO_IGNORE_PATHS .= ",${GPG_PATH}"
 USER_KEY_SHOW_VERBOSE = "1"
 
 UEFI_SB = '${@bb.utils.contains("DISTRO_FEATURES", "efi-secure-boot", "1", "0", d)}'


### PR DESCRIPTION
Adapt to recent psuedo changes.

Fixes:
ERROR: grub-efi-2.04-r0 do_sign: Failed to import gpg key
gpg: key 9E3086F96EEECC34/9E3086F96EEECC34: error sending to agent: End of file

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>