### PR TITLE
meta-encrypted-storage: set CONFIG_HW_RANDOM_TPM to "y"

### DIFF
--- a/meta-encrypted-storage/recipes-kernel/linux/linux-yocto/dmcrypt.cfg
+++ b/meta-encrypted-storage/recipes-kernel/linux/linux-yocto/dmcrypt.cfg
@@ -8,4 +8,4 @@ CONFIG_CRYPTO_XTS=y
 
 # Use entropy-strong source for RNG
 CONFIG_HW_RANDOM=y
-CONFIG_HW_RANDOM_TPM=m
+CONFIG_HW_RANDOM_TPM=y


### PR DESCRIPTION
CONFIG_HW_RANDOM_TPM is bool, not tristate, and thus it cannot be
set to "m"

Signed-off-by: Yongxin Liu <yongxin.liu@windriver.com>