### PR TITLE
rpm: apply signatures to config files

### DIFF
--- a/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
+++ b/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
@@ -9,3 +9,12 @@ EXTRA_OECONF_remove += "\
     --disable-plugins \
 "
 EXTRA_OECONF_append_class-native = " --disable-inhibit-plugin"
+
+SRC_URI_append = " \
+                  file://macros.ima \
+                 "
+
+do_install_append () {
+    install -d ${D}${sysconfdir}/rpm
+    install -m 0644 ${WORKDIR}/macros.ima ${D}${sysconfdir}/rpm/
+}

--- a/meta-integrity/recipes-devtools/rpm/rpm/macros.ima
+++ b/meta-integrity/recipes-devtools/rpm/rpm/macros.ima
@@ -1,0 +1,1 @@
+%_ima_sign_config_files		1


### PR DESCRIPTION
Since rpm 4.15, the users can control over the installation of
signatures on config files through a variable named
%_ima_sign_config_files. But this is disabled by default. Add a macro
configuration file to enable it.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>