### PR TITLE
tpm2simulator-native: fix native inheritance order

### DIFF
--- a/meta-tpm2/recipes-devtools/tpm2simulator/tpm2simulator-native_git.bb
+++ b/meta-tpm2/recipes-devtools/tpm2simulator/tpm2simulator-native_git.bb
@@ -22,7 +22,7 @@ SRCREV = "e45324eba268723d39856111e7933c5c76238481"
 
 S = "${WORKDIR}/git"
 
-inherit native pythonnative lib_package cmake
+inherit pythonnative lib_package cmake native
 
 EXTRA_OECMAKE = "\
     -DCMAKE_BUILD_TYPE=Debug \


### PR DESCRIPTION
Classes native/nativesdk must be inherited last to prevent unexpected
behaviour.

Fixes QA warning:
QA Issue: tpm2simulator-native: native/nativesdk class is not inherited
last, this can result in unexpected behaviour. Classes inherited after
native/nativesdk: cmake.bbclass lib_package.bbclass python-dir.bbclass
pythonnative.bbclass [native-last]

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>