### PR TITLE
libsign: fix dependency loop error

### DIFF
--- a/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
+++ b/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
@@ -50,6 +50,6 @@ FILES_${PN} += "\
 "
 
 RDEPENDS_${PN}_class-target += "libcrypto"
-RDEPENDS_${PN}_class-native += "openssl"
+RDEPENDS_${PN}_class-native += "openssl-native"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
fix below error caused by: openssl->libsign-native->openssl
DEBUG:	Dependency loop #1 found:
Dependency loop #1 found:
...

oe-core commits "bitbake.conf/python: Drop setting RDEPENDS/RPROVIDES default"
and "native: Stop clearing PACKAGES" refactor usage of RDEPENDS

Signed-off-by: Changqing Li <changqing.li@windriver.com>