### PR TITLE
grub: Drop useless insmod verify from cfg

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -81,17 +81,13 @@ python __anonymous () {
 do_compile_append() {
 	if [ "${GRUB_SIGN_VERIFY}" = "1" -a "${GRUB_SIGN_VERIFY_STRICT}" = "1" ] ; then
 		cat<<EOF>${WORKDIR}/cfg
-insmod verify
 set strict_security=1
-search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
-set prefix=(\$root)${GRUB_PREFIX_DIR}
-EOF
-	else
-		cat<<EOF>${WORKDIR}/cfg
-search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
-set prefix=(\$root)${GRUB_PREFIX_DIR}
 EOF
 	fi
+	cat<<EOF>>${WORKDIR}/cfg
+search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
+set prefix=(\$root)${GRUB_PREFIX_DIR}
+EOF
 }
 
 do_compile_append_class-native() {


### PR DESCRIPTION
- the 'verify' grub module has been renamed to 'pgp' in grub 2.04;
- the 'pgp' grub module is already built-in if GRUB_SIGN_VERIFY is set,
  so there's no need to call insmod;

While at it, remove some unnecessary code duplication.