### PR TITLE
Revert "grub-efi: refresh patches for grub 2.06"

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -28,6 +28,7 @@ SRC_URI_append_class-target += "\
     file://Grub-get-and-set-efi-variables.patch \
     file://uefi_verify.patch \
     file://0001-grub-verify-Add-strict_security-variable.patch \
+    file://0001-fs-ext2-fix-the-file-not-found-error-when-symlink-fi.patch \
     file://grub-efi.cfg \
     file://boot-menu.inc \
     ${@d.getVar('GRUB_MOKVERIFY_PATCH', True) if d.getVar('UEFI_SELOADER', True) == '1' else ''} \

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0001-fs-ext2-fix-the-file-not-found-error-when-symlink-fi.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0001-fs-ext2-fix-the-file-not-found-error-when-symlink-fi.patch
@@ -1,0 +1,40 @@
+From 5fe53d80b7294198687a96e72471ddb968c7de34 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Wed, 6 Jan 2021 17:07:26 +0800
+Subject: [PATCH] fs/ext2: fix the file not found error when symlink filesize
+ is 60
+
+We encountered a file not found error when the symlink filesize is 60:
+$ ls -l initrd
+lrwxrwxrwx 1 root root 60 Jan  6 16:37 initrd -> secure-core-image-initramfs-5.10.2-yoctodev-standard.cpio.gz
+
+When booting, we got the following error in grub:
+error: file `/initrd' not found
+
+The root cause is although the size of diro->inode.symlink is 60, it
+includes the trailing '\0'. So if the symlink filesize is exactly 60, it
+is also stored in a separate block rather than in the inode.
+
+Upstream-Status: Submitted [https://lists.gnu.org/archive/html/grub-devel/2021-01/msg00018.html]
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ grub-core/fs/ext2.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/grub-core/fs/ext2.c b/grub-core/fs/ext2.c
+index ac33bcd68..cb5058e8b 100644
+--- a/grub-core/fs/ext2.c
++++ b/grub-core/fs/ext2.c
+@@ -732,7 +732,7 @@ grub_ext2_read_symlink (grub_fshelp_node_t node)
+   /* If the filesize of the symlink is bigger than
+      60 the symlink is stored in a separate block,
+      otherwise it is stored in the inode.  */
+-  if (grub_le_to_cpu32 (diro->inode.size) <= sizeof (diro->inode.symlink))
++  if (grub_le_to_cpu32 (diro->inode.size) < sizeof (diro->inode.symlink))
+     grub_memcpy (symlink,
+ 		 diro->inode.symlink,
+ 		 grub_le_to_cpu32 (diro->inode.size));
+-- 
+2.25.1
+

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0001-grub-verify-Add-strict_security-variable.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0001-grub-verify-Add-strict_security-variable.patch
@@ -1,7 +1,7 @@
-From 9f330999565e1e82ce5b9460ffefa933cc47d67c Mon Sep 17 00:00:00 2001
+From 8a7ad88b4880e25df1f54b80631dc035e1e25662 Mon Sep 17 00:00:00 2001
 From: Jason Wessel <jason.wessel@windriver.com>
 Date: Thu, 17 Oct 2019 12:35:01 -0700
-Subject: [PATCH] grub verify: Add strict_security variable
+Subject: [PATCH] grub verify:  Add strict_security variable
 
 With strict_security set to 1, it is impossible to change the value of
 check_signatures.  It will also cause grub to reboot instead of
@@ -12,16 +12,14 @@ Upstream-Status: Pending
 
 Signed-off-by: Jason Wessel <jason.wessel@windriver.com>
 ---
- grub-core/commands/pgp.c | 16 +++++++++++++++-
- grub-core/kern/main.c    |  9 +++++++++
- grub-core/normal/main.c  |  7 +++++--
+ grub-core/commands/pgp.c |   16 +++++++++++++++-
+ grub-core/kern/main.c    |    9 +++++++++
+ grub-core/normal/main.c  |    7 +++++--
  3 files changed, 29 insertions(+), 3 deletions(-)
 
-diff --git a/grub-core/commands/pgp.c b/grub-core/commands/pgp.c
-index 5daa1e9..ed8514c 100644
 --- a/grub-core/commands/pgp.c
 +++ b/grub-core/commands/pgp.c
-@@ -864,6 +864,7 @@ grub_cmd_verify_signature (grub_extcmd_context_t ctxt,
+@@ -864,6 +864,7 @@ grub_cmd_verify_signature (grub_extcmd_c
  }
  
  static int sec = 0;
@@ -62,19 +60,17 @@ index 5daa1e9..ed8514c 100644
  
    grub_pk_trusted = 0;
    FOR_MODULES (header)
-diff --git a/grub-core/kern/main.c b/grub-core/kern/main.c
-index 73967e2..86e7f35 100644
 --- a/grub-core/kern/main.c
 +++ b/grub-core/kern/main.c
-@@ -30,6 +30,7 @@
+@@ -29,6 +29,7 @@
+ #include <grub/command.h>
  #include <grub/reader.h>
  #include <grub/parser.h>
- #include <grub/verify.h>
 +#include <grub/time.h>
  
  #ifdef GRUB_MACHINE_PCBIOS
  #include <grub/machine/memory.h>
-@@ -312,5 +313,13 @@ grub_main (void)
+@@ -308,5 +309,13 @@ grub_main (void)
    grub_boot_time ("After execution of embedded config. Attempt to go to normal mode");
  
    grub_load_normal_mode ();
@@ -88,11 +84,9 @@ index 73967e2..86e7f35 100644
 +    }
    grub_rescue_run ();
  }
-diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
-index c4ebe9e..2c3f4f8 100644
 --- a/grub-core/normal/main.c
 +++ b/grub-core/normal/main.c
-@@ -302,8 +302,11 @@ grub_enter_normal_mode (const char *config)
+@@ -301,8 +301,11 @@ grub_enter_normal_mode (const char *conf
    grub_boot_time ("Entering normal mode");
    nested_level++;
    grub_normal_execute (config, 0, 0);
@@ -106,6 +100,3 @@ index c4ebe9e..2c3f4f8 100644
    nested_level--;
    if (grub_normal_exit_level)
      grub_normal_exit_level--;
--- 
-2.17.1
-

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/Grub-get-and-set-efi-variables.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/Grub-get-and-set-efi-variables.patch
@@ -158,7 +158,7 @@ index 0000000..6aeda80
 +  if (EFI_VAR_INVALID == efi_type)
 +    return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("invalid format specifier"));
 +
-+  grub_efi_get_variable (args[0], &global, &efi_var_size, &efi_var);
++  efi_var = grub_efi_get_variable (args[0], &global, &efi_var_size);
 +  if (!efi_var || !efi_var_size)
 +    {
 +      status = grub_error (GRUB_ERR_READ_ERROR, N_("cannot read variable"));

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/mok2verify-support-to-verify-non-PE-file-with-PKCS-7.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/mok2verify-support-to-verify-non-PE-file-with-PKCS-7.patch
@@ -1,4 +1,4 @@
-From 14eda2e512ec14fcae9de63f87457e4dad1a0206 Mon Sep 17 00:00:00 2001
+From 3aa619ea2c9d35cc242f0ae870782522176ce018 Mon Sep 17 00:00:00 2001
 From: Lans Zhang <jia.zhang@windriver.com>
 Date: Wed, 12 Jul 2017 16:02:13 +0800
 Subject: [PATCH] mok2verify: support to verify non-PE file with PKCS#7
@@ -52,10 +52,10 @@ Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
  create mode 100644 include/grub/efi/mok2verify.h
 
 diff --git a/grub-core/Makefile.core.def b/grub-core/Makefile.core.def
-index 2f2765e..f07d6ea 100644
+index 18d2316..59a5cf1 100644
 --- a/grub-core/Makefile.core.def
 +++ b/grub-core/Makefile.core.def
-@@ -1894,6 +1894,12 @@ module = {
+@@ -1869,6 +1869,12 @@ module = {
    enable = efi;
  };
  
@@ -101,7 +101,7 @@ index bbca81e..3f44a7e 100644
    grub_machine_fini (grub_loader_flags);
  
 diff --git a/grub-core/gfxmenu/gui_label.c b/grub-core/gfxmenu/gui_label.c
-index 1c19054..52d4755 100644
+index a4c8178..da49c9e 100644
 --- a/grub-core/gfxmenu/gui_label.c
 +++ b/grub-core/gfxmenu/gui_label.c
 @@ -24,6 +24,9 @@
@@ -157,11 +157,11 @@ index 1c19054..52d4755 100644
 +		  value = _("enter: boot, `e': options, `c': cmd-line");
 +	     }
  	   /* FIXME: Add more templates here if needed.  */
- 
- 	  if (grub_printf_fmt_check(value, "%d") != GRUB_ERR_NONE)
+ 	  self->template = grub_strdup (value);
+ 	  self->text = grub_xasprintf (value, self->value);
 diff --git a/grub-core/lib/efi/mok2verify.c b/grub-core/lib/efi/mok2verify.c
 new file mode 100644
-index 0000000..eb268a2
+index 0000000..790efa0
 --- /dev/null
 +++ b/grub-core/lib/efi/mok2verify.c
 @@ -0,0 +1,182 @@
@@ -241,11 +241,11 @@ index 0000000..eb268a2
 +grub_is_secured (void)
 +{
 +  grub_efi_guid_t global_guid = GRUB_EFI_GLOBAL_VARIABLE_GUID;
-+  void *var = NULL;
++  void *var;
 +  grub_size_t var_size = 0;
 +  int secured = 0;
 +
-+  grub_efi_get_variable ("SecureBoot", &global_guid, &var_size, &var);
++  var = grub_efi_get_variable ("SecureBoot", &global_guid, &var_size);
 +  if (!var)
 +    return grub_error (GRUB_ERR_READ_ERROR, N_("cannot read variable"));
 +
@@ -254,8 +254,8 @@ index 0000000..eb268a2
 +
 +  grub_free (var);
 +
-+  grub_efi_get_variable ("MokSBState", &grub_efi_mok2_verify_protoco_guid,
-+			       &var_size, &var);
++  var = grub_efi_get_variable ("MokSBState", &grub_efi_mok2_verify_protoco_guid,
++			       &var_size);
 +  if (!var || (var_size == 1 && *(grub_uint8_t *) var == 0))
 +    secured = 1;
 +
@@ -348,20 +348,20 @@ index 0000000..eb268a2
 +
 +#pragma GCC diagnostic error "-Wvla"
 diff --git a/grub-core/loader/i386/linux.c b/grub-core/loader/i386/linux.c
-index 14d6a80..cfbb858 100644
+index 3a264b9..9caabdd 100644
 --- a/grub-core/loader/i386/linux.c
 +++ b/grub-core/loader/i386/linux.c
-@@ -41,6 +41,9 @@
+@@ -40,6 +40,9 @@
+ #include <grub/lib/cmdline.h>
  #include <grub/linux.h>
  #include <grub/machine/kernel.h>
- #include <grub/safemath.h>
 +#ifdef GRUB_MACHINE_EFI
 +#include <grub/efi/mok2verify.h>
 +#endif
  
  GRUB_MOD_LICENSE ("GPLv3+");
  
-@@ -664,6 +667,55 @@ grub_shim_verify (grub_addr_t addr, grub_ssize_t size)
+@@ -656,6 +659,55 @@ grub_shim_verify (grub_addr_t addr, grub_ssize_t size)
    return GRUB_ERR_NONE;
  }
  
@@ -417,7 +417,7 @@ index 14d6a80..cfbb858 100644
  static grub_err_t
  grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
  		int argc, char *argv[])
-@@ -686,6 +738,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
+@@ -678,6 +730,9 @@ grub_cmd_linux (grub_command_t cmd __attribute__ ((unused)),
        goto fail;
      }
  
@@ -427,7 +427,7 @@ index 14d6a80..cfbb858 100644
    file = grub_file_open (argv[0], GRUB_FILE_TYPE_LINUX_KERNEL);
    if (! file)
      goto fail;
-@@ -1145,6 +1200,11 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
+@@ -1139,6 +1194,11 @@ grub_cmd_initrd (grub_command_t cmd __attribute__ ((unused)),
   fail:
    grub_initrd_close (&initrd_ctx);
  
@@ -440,7 +440,7 @@ index 14d6a80..cfbb858 100644
  }
  
 diff --git a/grub-core/loader/linux.c b/grub-core/loader/linux.c
-index 3fe390f..8b743d7 100644
+index 8c8565a..7b989d4 100644
 --- a/grub-core/loader/linux.c
 +++ b/grub-core/loader/linux.c
 @@ -5,6 +5,9 @@
@@ -453,7 +453,7 @@ index 3fe390f..8b743d7 100644
  
  struct newc_head
  {
-@@ -278,6 +281,7 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
+@@ -279,6 +282,7 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
    int newc = 0;
    struct dir *root = 0;
    grub_ssize_t cursize = 0;
@@ -461,7 +461,7 @@ index 3fe390f..8b743d7 100644
  
    for (i = 0; i < initrd_ctx->nfiles; i++)
      {
-@@ -321,6 +325,25 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
+@@ -322,6 +326,25 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
  	  grub_initrd_close (initrd_ctx);
  	  return grub_errno;
  	}
@@ -487,7 +487,7 @@ index 3fe390f..8b743d7 100644
        ptr += cursize;
      }
    if (newc)
-@@ -329,7 +352,9 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
+@@ -330,7 +353,9 @@ grub_initrd_load (struct grub_linux_initrd_context *initrd_ctx,
        ptr += ALIGN_UP_OVERHEAD (cursize, 4);
        ptr = make_header (ptr, "TRAILER!!!", sizeof ("TRAILER!!!") - 1, 0, 0);
      }
@@ -499,10 +499,10 @@ index 3fe390f..8b743d7 100644
 +  return err;
  }
 diff --git a/grub-core/normal/main.c b/grub-core/normal/main.c
-index 2c3f4f8..c97df84 100644
+index 316ce53..5610106 100644
 --- a/grub-core/normal/main.c
 +++ b/grub-core/normal/main.c
-@@ -34,6 +34,9 @@
+@@ -33,6 +33,9 @@
  #include <grub/charset.h>
  #include <grub/script_sh.h>
  #include <grub/bufio.h>
@@ -512,7 +512,7 @@ index 2c3f4f8..c97df84 100644
  
  GRUB_MOD_LICENSE ("GPLv3+");
  
-@@ -196,6 +199,8 @@ read_config_file (const char *config)
+@@ -195,6 +198,8 @@ read_config_file (const char *config)
    return newmenu;
  }
  
@@ -521,7 +521,7 @@ index 2c3f4f8..c97df84 100644
  /* Initialize the screen.  */
  void
  grub_normal_init_page (struct grub_term_output *term,
-@@ -203,13 +208,24 @@ grub_normal_init_page (struct grub_term_output *term,
+@@ -202,13 +207,24 @@ grub_normal_init_page (struct grub_term_output *term,
  {
    grub_ssize_t msg_len;
    int posx;
@@ -547,7 +547,7 @@ index 2c3f4f8..c97df84 100644
    if (!msg_formatted)
      return;
   
-@@ -234,6 +250,8 @@ grub_normal_init_page (struct grub_term_output *term,
+@@ -233,6 +249,8 @@ grub_normal_init_page (struct grub_term_output *term,
    grub_free (unicode_msg);
  }
  
@@ -556,7 +556,7 @@ index 2c3f4f8..c97df84 100644
  static void
  read_lists (const char *val)
  {
-@@ -274,6 +292,20 @@ grub_normal_execute (const char *config, int nested, int batch)
+@@ -273,6 +291,20 @@ grub_normal_execute (const char *config, int nested, int batch)
  
    if (config)
      {
@@ -577,7 +577,7 @@ index 2c3f4f8..c97df84 100644
        menu = read_config_file (config);
  
        /* Ignore any error.  */
-@@ -305,7 +337,10 @@ grub_enter_normal_mode (const char *config)
+@@ -304,7 +336,10 @@ grub_enter_normal_mode (const char *config)
    const char *val = grub_env_get ("strict_security");
    if (!(val && (val[0] == '1' || val[0] == 'e'))) {
      grub_boot_time ("Entering shell");
@@ -589,7 +589,7 @@ index 2c3f4f8..c97df84 100644
    }
    nested_level--;
    if (grub_normal_exit_level)
-@@ -359,6 +394,13 @@ grub_cmd_normal (struct grub_command *cmd __attribute__ ((unused)),
+@@ -341,6 +376,13 @@ grub_cmd_normal (struct grub_command *cmd __attribute__ ((unused)),
      grub_enter_normal_mode (argv[0]);
  
  quit:
@@ -603,7 +603,7 @@ index 2c3f4f8..c97df84 100644
    return 0;
  }
  
-@@ -546,8 +588,11 @@ GRUB_MOD_INIT(normal)
+@@ -528,8 +570,11 @@ GRUB_MOD_INIT(normal)
    /* Register a command "normal" for the rescue mode.  */
    grub_register_command ("normal", grub_cmd_normal,
  			 0, N_("Enter normal mode."));
@@ -618,7 +618,7 @@ index 2c3f4f8..c97df84 100644
    /* Reload terminal colors when these variables are written to.  */
    grub_register_variable_hook ("color_normal", NULL, grub_env_write_color_normal);
 diff --git a/grub-core/normal/menu.c b/grub-core/normal/menu.c
-index 8397886..76c3f5a 100644
+index d5e0c79..512f710 100644
 --- a/grub-core/normal/menu.c
 +++ b/grub-core/normal/menu.c
 @@ -32,6 +32,9 @@
@@ -631,7 +631,7 @@ index 8397886..76c3f5a 100644
  
  /* Time to delay after displaying an error message about a default/fallback
     entry failing to boot.  */
-@@ -772,18 +775,30 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
+@@ -773,18 +776,30 @@ run_menu (grub_menu_t menu, int nested, int *auto_boot)
  	      break;
  
  	    case 'c':


### PR DESCRIPTION
Gatesgarth still uses grub 2.04.

This reverts commit 4e1cc676dc566de9b9f779d4209dd28fa7a80788.