### PR TITLE
prevent contamining the cache with embeded cfg

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -85,6 +85,8 @@ do_compile_append_class-target() {
 		cat<<EOF>${WORKDIR}/cfg
 set strict_security=1
 EOF
+  else
+    > ${WORKDIR}/cfg
 	fi
 	cat<<EOF>>${WORKDIR}/cfg
 search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root


### PR DESCRIPTION
This should fix #202 . Here we simply clean the file if the variable GRUB_SIGN_VERIFY_STRICT is set to `0`. This will ensure the `cfg` file to represent the variable state. This will also fix an issue where the embedded configuration would contains the `search.file` twice when the variable `GRUB_SIGN_VERIFY_STRICT=0`