### PR TITLE
Fix the kernel include file

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -172,7 +172,7 @@ python do_sign() {
 addtask sign after do_install before do_deploy do_package
 
 fakeroot do_chownboot() {
-    if [ "${GRUB_SIGN_VERIFY}" = "1"]; then
+    if [ "${GRUB_SIGN_VERIFY}" = "1" ]; then
         chown root:root -R "${D}${EFI_BOOT_PATH}/grub.cfg${SB_FILE_EXT}"
         chown root:root -R "${D}${EFI_BOOT_PATH}/boot-menu.inc${SB_FILE_EXT}"
         [ x"${UEFI_SB}" = x"1" ] && {

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -86,6 +86,8 @@ do_compile_append_class-target() {
 		cat<<EOF>${WORKDIR}/cfg
 set strict_security=1
 EOF
+  else
+    > ${WORKDIR}/cfg
 	fi
 	cat<<EOF>>${WORKDIR}/cfg
 search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root

--- a/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
@@ -18,6 +18,10 @@ fakeroot python do_sign() {
     if d.expand('${UEFI_SB}') != '1':
         return
 
+    if d.expand('${UEFI_SELOADER}') == '0' and d.expand('${GRUB_SIGN_VERIFY}') == '0':
+        bb.debug(1, "Skipping signature, no bootloader need it")
+        return
+
     import shutil
 
     for type in d.expand('${KERNEL_IMAGETYPES}').split():
@@ -29,6 +33,8 @@ fakeroot python do_sign() {
         # SELoader signature is always based on the unsigned kernel image,
         # disallowing chainloader to kernel efi-stub.
         uks_bl_sign(kernel, d)
+
+        #if d.getVar('GRUB_SIGN_VERIFY', True) == "1":
 
         shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-${KERNEL_RELEASE}'))
         ext = d.expand('${SB_FILE_EXT}')
@@ -54,6 +60,10 @@ fakeroot python do_sign_bundled_kernel() {
     if (d.expand('${INITRAMFS_IMAGE}') == '') or (d.expand('${INITRAMFS_IMAGE_BUNDLE}') != '1'):
         return
 
+    if d.expand('${UEFI_SELOADER}') == '0' and d.expand('${GRUB_SIGN_VERIFY}') == '0':
+        bb.debug(1, "Skipping signature, no bootloader need it")
+        return
+
     import shutil
 
     for type in d.expand('${KERNEL_IMAGETYPES}').split():
@@ -66,9 +76,10 @@ fakeroot python do_sign_bundled_kernel() {
         # disallowing chainloader to kernel efi-stub.
         uks_bl_sign(kernel, d)
 
-        shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin'))
-        ext = d.expand('${SB_FILE_EXT}')
-        shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin' + ext))
+        if d.getVar('GRUB_SIGN_VERIFY', True) == "1":
+            shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin'))
+            ext = d.expand('${SB_FILE_EXT}')
+            shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin' + ext))
 }
 addtask sign_bundled_kernel after do_bundle_initramfs before do_deploy
 

--- a/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
@@ -34,7 +34,6 @@ fakeroot python do_sign() {
         # disallowing chainloader to kernel efi-stub.
         uks_bl_sign(kernel, d)
 
-        #if d.getVar('GRUB_SIGN_VERIFY', True) == "1":
 
         shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-${KERNEL_RELEASE}'))
         ext = d.expand('${SB_FILE_EXT}')
@@ -76,10 +75,9 @@ fakeroot python do_sign_bundled_kernel() {
         # disallowing chainloader to kernel efi-stub.
         uks_bl_sign(kernel, d)
 
-        if d.getVar('GRUB_SIGN_VERIFY', True) == "1":
-            shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin'))
-            ext = d.expand('${SB_FILE_EXT}')
-            shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin' + ext))
+        shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin'))
+        ext = d.expand('${SB_FILE_EXT}')
+        shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-initramfs-${MACHINE}.bin' + ext))
 }
 addtask sign_bundled_kernel after do_bundle_initramfs before do_deploy
 


### PR DESCRIPTION
1. In #207  I forgot to check the variable in the kernel include. The task would fail if GRUB_SIGN_VERIFY is set to 0. Before #207 , it would crash so this will fix both.
2. Include the #203 path which has been introduce to master, but not in this branch
3. #207 Introduce a typo in the `do_chowboot` which will make the build fail with a host contamination error.

This will make #206 working as expected.