### PR TITLE
linux-yocto-efi-secure-boot.inc: fix rerun failure

### DIFF
--- a/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-kernel/linux/linux-yocto-efi-secure-boot.inc
@@ -38,7 +38,10 @@ fakeroot python do_sign() {
         shutil.copyfile(kernel, d.expand('${D}/boot/') + type + d.expand('-${KERNEL_RELEASE}'))
         ext = d.expand('${SB_FILE_EXT}')
         shutil.copyfile(kernel + ext, d.expand('${D}/boot/') + type + d.expand('-${KERNEL_RELEASE}' + ext))
-        os.symlink(type + d.expand('-${KERNEL_RELEASE}' + ext), d.expand('${D}/boot/') + type + ext)
+        dst = d.expand('${D}/boot/') + type + ext
+        if os.path.exists(dst):
+            os.unlink(dst)
+        os.symlink(type + d.expand('-${KERNEL_RELEASE}' + ext), dst)
 }
 
 # Make sure the kernel image has been signed before kernel_do_deploy()


### PR DESCRIPTION
Cherry-pick fix from master branch to gatesgarth (original commit message below):

Task do_sign of linux-yocto depends on variable GPG_PATH. When GPG_PATH
changes, it fails to rerun the task:

| Exception: FileExistsError: [Errno 17] File exists:
| 'bzImage-5.2.24-yocto-standard.p7b' -> '/path/to/tmp-glibc/work/intel_x86_64-wrs-linux/linux-yocto/5.2.x+gitAUTOINC+bbe834c1d2_370ab92a1e-r0/image/boot/bzImage.p7b'

Remove the link file before create it if exists already.