### PR TITLE
tpm2-tools: fix CVE-2021-3565

### DIFF
--- a/meta-tpm2/recipes-tpm/tpm2-tools/files/CVE-2021-3565.patch
+++ b/meta-tpm2/recipes-tpm/tpm2-tools/files/CVE-2021-3565.patch
@@ -1,0 +1,53 @@
+From 47b3b6e6fffed7080a2f1ce7673207ea44823ef7 Mon Sep 17 00:00:00 2001
+From: William Roberts <william.c.roberts@intel.com>
+Date: Fri, 21 May 2021 12:22:31 -0500
+Subject: [PATCH] tpm2_import: fix fixed AES key CVE-2021-3565
+
+tpm2_import used a fixed AES key for the inner wrapper, which means that
+a MITM attack would be able to unwrap the imported key. Even the
+use of an encrypted session will not prevent this. The TPM only
+encrypts the first parameter which is the fixed symmetric key.
+
+To fix this, ensure the key size is 16 bytes or bigger and use
+OpenSSL to generate a secure random AES key.
+
+Fixes: #2738
+
+Signed-off-by: William Roberts <william.c.roberts@intel.com>
+
+Upstream-Status: Backport
+[https://github.com/tpm2-software/tpm2-tools/commit/c069e4f179d5e6653a84fb236816c375dca82515]
+
+CVE: CVE-2021-3565
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ tools/tpm2_import.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
+
+diff --git a/tools/tpm2_import.c b/tools/tpm2_import.c
+index 50072894..ee5dec15 100644
+--- a/tools/tpm2_import.c
++++ b/tools/tpm2_import.c
+@@ -118,7 +118,17 @@ static tool_rc key_import(ESYS_CONTEXT *ectx, TPM2B_PUBLIC *parent_pub,
+     TPM2B_DATA enc_sensitive_key = {
+         .size = parent_pub->publicArea.parameters.rsaDetail.symmetric.keyBits.sym / 8
+     };
+-    memset(enc_sensitive_key.buffer, 0xFF, enc_sensitive_key.size);
++
++    if(enc_sensitive_key.size < 16) {
++        LOG_ERR("Calculated wrapping keysize is less than 16 bytes, got: %u", enc_sensitive_key.size);
++        return tool_rc_general_error;
++    }
++
++    int ossl_rc = RAND_bytes(enc_sensitive_key.buffer, enc_sensitive_key.size);
++    if (ossl_rc != 1) {
++        LOG_ERR("RAND_bytes failed: %s", ERR_error_string(ERR_get_error(), NULL));
++        return tool_rc_general_error;
++    }
+ 
+     /*
+      * Calculate the object name.
+-- 
+2.25.1
+

--- a/meta-tpm2/recipes-tpm/tpm2-tools/tpm2-tools_4.1.3.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-tools/tpm2-tools_4.1.3.bb
@@ -8,6 +8,7 @@ DEPENDS = "tpm2-abrmd tpm2-tss openssl curl autoconf-archive"
 
 SRC_URI = "https://github.com/tpm2-software/${BPN}/releases/download/${PV}/${BPN}-${PV}.tar.gz \
            file://0001-tests-switch-to-python3.patch \
+           file://CVE-2021-3565.patch \
           "
 
 SRC_URI[md5sum] = "48e0f58232b6a86fe4d007acf12af283"


### PR DESCRIPTION
CVE-2021-3565:
A flaw was found in tpm2-tools in versions before 5.1.1 and before
4.3.2. tpm2_import used a fixed AES key for the inner wrapper,
potentially allowing a MITM attacker to unwrap the inner portion and
reveal the key being imported. The highest threat from this
vulnerability is to data confidentiality.

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2021-3565

Patch from:
https://github.com/tpm2-software/tpm2-tools/commit/c069e4f179d5e6653a84fb236816c375dca82515

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>