### PR TITLE
shim_git: fix the do_fetch warning

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -20,7 +20,7 @@ DEPENDS += "\
 PV = "12+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/rhboot/shim.git \
+    git://github.com/rhboot/shim.git;branch=main \
     file://0001-shim-allow-to-verify-sha1-digest-for-Authenticode.patch;apply=0 \
     file://0005-Fix-signing-failure-due-to-not-finding-certificate.patch;apply=0 \
     file://0006-Prevent-from-removing-intermediate-.efi.patch \


### PR DESCRIPTION
Issue: LIN1021-738 LIN1021-990

Fixes:
WARNING: shim-12+gitAUTOINC+5202f80c32-r0 do_fetch: Failed to fetch URL git://github.com/rhboot/shim.git, attempting MIRRORS if available

(LOCAL REV: NOT UPSTREAM) -- sent to meta-secure-core 20210729

Signed-off-by: Mingli Yu <mingli.yu@windriver.com>