### PR TITLE
cryptfs-tpm2: fix encrypt_secret.py for python3

### DIFF
--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2/0001-encrypt_secret.py-fix-for-python3.patch
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2/0001-encrypt_secret.py-fix-for-python3.patch
@@ -1,0 +1,56 @@
+From bfdfa6aea6f0c4ca5b075d172ef510899af01962 Mon Sep 17 00:00:00 2001
+From: Yi Zhao <yi.zhao@windriver.com>
+Date: Fri, 20 Aug 2021 17:34:42 +0800
+Subject: [PATCH] encrypt_secret.py: fix for python3
+
+Fixes:
+encrypt_secret.py -i "H31i05" > "primary_key.secret" || exit 1
+ERROR: Unable to encrypt the secret
+
+Upstream-Status: Pending
+
+Signed-off-by: Yi Zhao <yi.zhao@windriver.com>
+---
+ scripts/encrypt_secret.py.in | 16 +++++++++-------
+ 1 file changed, 9 insertions(+), 7 deletions(-)
+
+diff --git a/scripts/encrypt_secret.py.in b/scripts/encrypt_secret.py.in
+index ffd3213..e739183 100755
+--- a/scripts/encrypt_secret.py.in
++++ b/scripts/encrypt_secret.py.in
+@@ -15,23 +15,25 @@ class Secret():
+     def encrypt(self, input):
+         _ = SECRET_XOR_BYTE_CODE
+ 
+-        input = bytes(input)
++        input = bytes(input, 'utf-8')
+         out = str()
+-        for b in input:
++        for i in input:
++            b = bytes([i])
+             b = struct.unpack('<1B', b)[0]
+             _ = b ^ _
+-            out = out + struct.pack('<1B', _)
++            out = out + struct.pack('<1B', _).decode('utf-8')
+ 
+         return out
+-             
++
+     def decrypt(self, input):
+         _ = SECRET_XOR_BYTE_CODE
+ 
+-        input = bytes(input)
++        input = bytes(input, 'utf-8')
+         out = str()
+-        for b in input:
++        for i in input:
++            b = bytes([i])
+             b = struct.unpack('<1B', b)[0]
+-            out = out + struct.pack('<1B', b ^ _)
++            out = out + struct.pack('<1B', b ^ _).decode('utf-8')
+             _ = b
+ 
+         return out
+-- 
+2.25.1
+

--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -27,6 +27,7 @@ SRC_URI = "\
     file://0001-lib-Makefile-set-correct-soname-for-libcryptfs-tpm2.patch \
     file://0001-Remove-build-time-from-show_banner.patch \
     file://0001-env.mk-fix-LDFLAGS-expansion.patch \
+    file://0001-encrypt_secret.py-fix-for-python3.patch \
 "
 SRCREV = "87c35c63090a33d4de437f518b8da9f2d1f1d828"
 


### PR DESCRIPTION
Fixes:
encrypt_secret.py -i "H31i05" > "primary_key.secret" || exit 1
ERROR: Unable to encrypt the secret

Suggested-by: Kai Kang <kai.kang@windriver.com>
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>