### PR TITLE
thud branch: fix sbsigningtool SRC_URI

### DIFF
--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -12,7 +12,7 @@ DEPENDS += "binutils openssl gnu-efi util-linux"
 PV = "0.6+git${SRCPV}"
 
 SRC_URI = "\
-    git://kernel.ubuntu.com/jk/sbsigntool \
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git;protocol=https \
     file://ccan.git.tar.bz2 \
     file://fix-mixed-implicit-and-normal-rules.patch;apply=0 \
     file://disable-man-page-creation.patch \


### PR DESCRIPTION
The SRC_URI git://kernel.ubuntu.com/jk/sbsigntool no longer exists. I've updated the SRC_URI to point to the new location.