### PR TITLE
sbsigntool: fix commented-out override syntax

### DIFF
--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -37,9 +37,9 @@ def efi_arch(d):
     return arch
 
 # Avoids build breaks when using no-static-libs.inc
-#DISABLE_STATIC_class-target = ""
+#DISABLE_STATIC:class-target = ""
 
-#EXTRA_OECONF_remove_class-target += "\
+#EXTRA_OECONF:remove:class-target += "\
 #    --with-libtool-sysroot \
 #"
 


### PR DESCRIPTION
Signed-off-by: Yi Zhao <yi.zhao@windriver.com>