### PR TITLE
rpm-native: disable audit plugin

### DIFF
--- a/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
+++ b/meta-integrity/recipes-devtools/rpm/rpm-integrity.inc
@@ -8,7 +8,7 @@ PACKAGECONFIG:append = " \
 EXTRA_OECONF:remove += "\
     --disable-plugins \
 "
-EXTRA_OECONF:append:class-native = " --disable-inhibit-plugin"
+EXTRA_OECONF:append:class-native = " --disable-inhibit-plugin --with-audit=no"
 
 SRC_URI:append = " \
                   file://macros.ima \


### PR DESCRIPTION
enable this plugin will cause undeterministic build. whether to build
audit plugin depends on whether libaudit exists on the host

Signed-off-by: Changqing Li <changqing.li@windriver.com>