### PR TITLE
grub-efi: Remove $cmdpath from configuration for for grub-mkimage

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -90,7 +90,7 @@ EOF
     > ${WORKDIR}/cfg
 	fi
 	cat<<EOF>>${WORKDIR}/cfg
-search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
+search.file ${GRUB_PREFIX_DIR}/grub.cfg root
 set prefix=(\$root)${GRUB_PREFIX_DIR}
 EOF
 }


### PR DESCRIPTION
Based on our discussion, let's remove `(\$cmdpath)` from `cfg` used for grub image generation.

Rationale: `search.file` is used to [search devices by file](https://www.gnu.org/software/grub/manual/grub/html_node/search.html); without a device prefix; which was included by `$cmdpath`.

