### PR TITLE
grub-efi: Remove $cmdpath from configuration for for grub-mkimage

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -89,7 +89,7 @@ EOF
     > ${WORKDIR}/cfg
 	fi
 	cat<<EOF>>${WORKDIR}/cfg
-search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
+search.file ${GRUB_PREFIX_DIR}/grub.cfg root
 set prefix=(\$root)${GRUB_PREFIX_DIR}
 EOF
 }


### PR DESCRIPTION
Same thing for master; see #226.