### PR TITLE
recipes: update SRC_URI branch and protocols

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
+++ b/meta-efi-secure-boot/recipes-bsp/efitools/efitools.inc
@@ -18,7 +18,7 @@ DEPENDS:append = " \
 PV = "1.9.2+git${SRCPV}"
 
 SRC_URI = "\
-    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git \
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/efitools.git;branch=master \
     file://Fix-for-the-cross-compilation.patch \
     file://Kill-all-the-build-warning-caused-by-implicit-declar.patch \
     file://Fix-the-wrong-dependency-for-blacklist.esl.patch \

--- a/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/seloader/seloader_git.bb
@@ -27,7 +27,7 @@ DEPENDS += "\
 PV = "0.4.6+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/jiazhang0/SELoader.git \
+    git://github.com/jiazhang0/SELoader.git;branch=master;protocol=https \
 "
 SRCREV = "8b90f76a8df51d9020e67824026556434f407086"
 

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -20,7 +20,7 @@ DEPENDS += "\
 PV = "12+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/rhboot/shim.git;branch=main \
+    git://github.com/rhboot/shim.git;branch=main;protocol=https \
     file://0001-shim-allow-to-verify-sha1-digest-for-Authenticode.patch;apply=0 \
     file://0005-Fix-signing-failure-due-to-not-finding-certificate.patch;apply=0 \
     file://0006-Prevent-from-removing-intermediate-.efi.patch \

--- a/meta-efi-secure-boot/recipes-extended/mokutil/mokutil_git.bb
+++ b/meta-efi-secure-boot/recipes-extended/mokutil/mokutil_git.bb
@@ -8,7 +8,7 @@ DEPENDS += "openssl efivar virtual/crypt"
 PV = "0.3.0+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/lcp/mokutil.git \
+    git://github.com/lcp/mokutil.git;branch=master;protocol=https \
     file://0001-mokutil.c-fix-typo-enrollement-enrollment.patch \
 "
 SRCREV = "e19adc575c1f9d8f08b7fbc594a0887ace63f83f"

--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -20,7 +20,7 @@ DEPENDS += "tpm2-tss tpm2-abrmd pkgconfig-native"
 PV = "0.7.0+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/jiazhang0/cryptfs-tpm2.git \
+    git://github.com/jiazhang0/cryptfs-tpm2.git;branch=master;protocol=https \
     file://0001-luks-setup.sh-Add-support-for-qemu-with-the-swtpm.patch \
     file://0002-luks-setup.sh-Updated-TPM-Tools.patch \
     file://0001-Remove-build-time-from-show_banner.patch \

--- a/meta-ids/recipes-ids/mtree/mtree_git.bb
+++ b/meta-ids/recipes-ids/mtree/mtree_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=bb19ea4eac951288efda4010c5c669a8"
 
 PV = "1.0.3+git${SRCPV}"
 
-SRC_URI = "git://github.com/archiecobbs/mtree-port.git \
+SRC_URI = "git://github.com/archiecobbs/mtree-port.git;branch=master;protocol=https \
            file://mtree-getlogin.patch \
            file://configure.ac-automake-error.patch \
            file://0001-compat-glibc-2.33.patch \

--- a/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.13.bb
+++ b/meta-integrity/recipes-support/ima-inspect/ima-inspect_0.13.bb
@@ -4,7 +4,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=a23a74b3f4caf9616230789d94217acb"
 DEPENDS += "attr ima-evm-utils tclap"
 
 SRC_URI = " \
-    git://github.com/mgerstner/ima-inspect.git \
+    git://github.com/mgerstner/ima-inspect.git;branch=master;protocol=https \
 "
 SRCREV = "90f395c84eff54c69ba9ee078274313cfd308b53"
 

--- a/meta-intel-sgx/recipes-kernel/intel-sgx-driver/intel-sgx-driver_2.1.bb
+++ b/meta-intel-sgx/recipes-kernel/intel-sgx-driver/intel-sgx-driver_2.1.bb
@@ -12,7 +12,7 @@ DEPENDS = "virtual/kernel"
 PV = "2.1+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/intel/linux-sgx-driver.git \
+    git://github.com/intel/linux-sgx-driver.git;branch=master;protocol=https \
 "
 SRCREV = "2a509c203533f9950fa3459fe91864051bc021a2"
 

--- a/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
+++ b/meta-signing-key/recipes-devtools/libsign/libsign_git.bb
@@ -19,7 +19,7 @@ DEPENDS += "openssl"
 PV = "0.3.2+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/jiazhang0/libsign.git \
+    git://github.com/jiazhang0/libsign.git;branch=master;protocol=https \
     file://0001-selsign.c-remove-build-time-from-show_banner.patch \
     file://0001-env.mk-fix-LDFLAGS-expansion.patch \
 "

--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -11,8 +11,8 @@ DEPENDS += "binutils openssl gnu-efi gnu-efi-native util-linux-libuuid"
 DEPENDS += "binutils-native help2man-native coreutils-native openssl-native util-linux-native"
 
 SRC_URI = " \
-    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git;protocol=https;name=sbsigntools \
-    git://github.com/rustyrussell/ccan.git;protocol=https;destsuffix=git/lib/ccan.git;name=ccan \
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools.git;protocol=https;name=sbsigntools;branch=master \
+    git://github.com/rustyrussell/ccan.git;protocol=https;destsuffix=git/lib/ccan.git;name=ccan;branch=master \
     file://0001-configure-Dont-t-check-for-gnu-efi.patch \
     file://0002-docs-Don-t-build-man-pages.patch \
     file://0003-sbsign-add-x-option-to-avoid-overwrite-existing-sign.patch  \

--- a/meta-tpm/recipes-tpm/openssl-tpm-engine/openssl-tpm-engine_0.5.0.bb
+++ b/meta-tpm/recipes-tpm/openssl-tpm-engine/openssl-tpm-engine_0.5.0.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=11f0ee3af475c85b907426e285c9bb52"
 DEPENDS += "openssl trousers"
 
 SRC_URI = "\
-    git://github.com/mgerstner/openssl_tpm_engine.git \
+    git://github.com/mgerstner/openssl_tpm_engine.git;branch=master;protocol=https \
     file://0001-create-tpm-key-support-well-known-key-option.patch \
     file://0002-libtpm-support-env-TPM_SRK_PW.patch \
     file://0003-tpm-openssl-tpm-engine-parse-an-encrypted-tpm-SRK-pa.patch \

--- a/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
+++ b/meta-tpm/recipes-tpm/pcr-extend/pcr-extend_git.bb
@@ -9,7 +9,7 @@ DEPENDS = "libtspi"
 PV = "0.1+git${SRCPV}"
 
 SRC_URI = "\
-    git://github.com/flihp/pcr-extend.git \
+    git://github.com/flihp/pcr-extend.git;branch=master;protocol=https \
 "
 SRCREV = "c02ad8f628b3d99f6d4c087b402fe31a40ee6316"
 

--- a/meta-tpm/recipes-tpm/tpm-quote-tools/tpm-quote-tools_git.bb
+++ b/meta-tpm/recipes-tpm/tpm-quote-tools/tpm-quote-tools_git.bb
@@ -18,7 +18,7 @@ DEPENDS = "libtspi tpm-tools"
 PV = "1.0.4+git${SRCPV}"
 
 SRC_URI = "\
-    git://git.code.sf.net/p/tpmquotetools/tpm-quote-tools \
+    git://git.code.sf.net/p/tpmquotetools/tpm-quote-tools;branch=master \
 "
 SRCREV = "d70da818778f641c05de8eb205fb72782e5555db"
 

--- a/meta-tpm/recipes-tpm/tpm-tools/tpm-tools_git.bb
+++ b/meta-tpm/recipes-tpm/tpm-tools/tpm-tools_git.bb
@@ -16,7 +16,7 @@ DEPENDS:class-native = "trousers-native"
 PV = "1.3.9.1+git${SRCPV}"
 
 SRC_URI = "\
-    git://git.code.sf.net/p/trousers/tpm-tools \
+    git://git.code.sf.net/p/trousers/tpm-tools;branch=master \
     file://tpm-tools-extendpcr.patch \
     file://03-fix-bool-error-parseStringWithValues.patch;apply=0 \
 "

--- a/meta-tpm/recipes-tpm/trousers/trousers_git.bb
+++ b/meta-tpm/recipes-tpm/trousers/trousers_git.bb
@@ -17,7 +17,7 @@ PROVIDES = "${PACKAGES}"
 PV = "0.3.14+git${SRCPV}"
 
 SRC_URI = "\
-    git://git.code.sf.net/p/trousers/trousers \
+    git://git.code.sf.net/p/trousers/trousers;branch=master \
     file://fix-deadlock-and-potential-hung.patch \
     file://fix-event-log-parsing-problem.patch \
     file://fix-incorrect-report-of-insufficient-buffer.patch \

--- a/meta-tpm/recipes-tpm/tss-testsuite/tss-testsuite_git.bb
+++ b/meta-tpm/recipes-tpm/tss-testsuite/tss-testsuite_git.bb
@@ -18,7 +18,7 @@ DEPENDS = "trousers"
 PV = "git${SRCPV}"
 
 SRC_URI = "\
-    git://git.code.sf.net/p/trousers/testsuite \
+    git://git.code.sf.net/p/trousers/testsuite;branch=master \
     file://fix-failure-of-.so-LD-with-cortexa8t-neon-wrswrap-linux.patch \
     file://testsuite-transport-init.patch \
     file://Tspi_TPM_LoadMaintenancePubKey01.patch \

--- a/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.3.3.bb
+++ b/meta-tpm2/recipes-tpm/tpm2-abrmd/tpm2-abrmd_2.3.3.bb
@@ -13,7 +13,7 @@ DEPENDS = "autoconf-archive dbus glib-2.0 tpm2-tss glib-2.0-native \
             libtss2 libtss2-mu libtss2-tcti-device libtss2-tcti-mssim"
 
 SRC_URI = "\
-    git://github.com/tpm2-software/tpm2-abrmd.git \
+    git://github.com/tpm2-software/tpm2-abrmd.git;branch=master;protocol=https \
     file://0001-Remove-obsolete-setting-regarding-the-Standard-Outpu.patch \
     file://tpm2-abrmd-init.sh \
     file://tpm2-abrmd.default \


### PR DESCRIPTION
Update SRC_URIs using git to include branch=master if no branch is set
and also to use protocol=https for github urls.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>