### PR TITLE
Revert "grub-efi: Remove $cmdpath from configuration for for grub-mki…

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -89,7 +89,7 @@ EOF
     > ${WORKDIR}/cfg
 	fi
 	cat<<EOF>>${WORKDIR}/cfg
-search.file ${GRUB_PREFIX_DIR}/grub.cfg root
+search.file (\$cmdpath)${GRUB_PREFIX_DIR}/grub.cfg root
 set prefix=(\$root)${GRUB_PREFIX_DIR}
 EOF
 }


### PR DESCRIPTION
…mage"

This reverts commit 5fcb2f0e67fa3f3607f65e317330cc8e045f1106.

$cmdpath is an important grub environment variable. Remove it will cause
the boot failure.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>