### PR TITLE
Updated the URI for Jeremy Kerr's sbsigntools

### DIFF
--- a/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
+++ b/meta-signing-key/recipes-devtools/sbsigntool/sbsigntool_git.bb
@@ -12,7 +12,7 @@ DEPENDS += "binutils openssl gnu-efi util-linux"
 PV = "0.6+git${SRCPV}"
 
 SRC_URI = "\
-    git://kernel.ubuntu.com/jk/sbsigntool \
+    git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools \
     file://ccan.git.tar.bz2 \
     file://fix-mixed-implicit-and-normal-rules.patch;apply=0 \
     file://disable-man-page-creation.patch \


### PR DESCRIPTION
Jeremy Kerr's sbsigntools are no longer hosted on git://kernel.ubuntu.com/jk/sbsigntool. A copy exists at git://git.kernel.org/pub/scm/linux/kernel/git/jejb/sbsigntools. This change is required to build meta-secure-core under sumo.