### PR TITLE
(conditionally) add 'tpm' to list of grub built-in modules

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -48,12 +48,16 @@ GRUB_SIGNING_MODULES += "${@'pgp gcry_rsa gcry_sha256 gcry_sha512 --pubkey %s ' 
 
 GRUB_SELOADER_MODULES += "${@'mok2verify ' if d.getVar('UEFI_SELOADER', True) == '1' else ''}"
 
+GRUB_TPM_MODULES += "${@bb.utils.contains('DISTRO_FEATURES', 'tpm' , 'tpm', '', d)}"
+GRUB_TPM_MODULES += "${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', 'tpm', '', d)}"
+
 GRUB_SECURE_BUILDIN ??= ""
 GRUB_SECURE_BUILDIN:append:class-target = " \
   tftp reboot chain \
   ${GRUB_SECURE_BOOT_MODULES} \
   ${GRUB_SIGNING_MODULES} \
-  ${GRUB_SELOADER_MODULES}"
+  ${GRUB_SELOADER_MODULES} \
+  ${GRUB_TPM_MODULES}"
 
 # For efi_call_foo and efi_shim_exit
 CFLAGS:append:class-target = " -fno-toplevel-reorder"


### PR DESCRIPTION
If tpm/tpm2 is enabled in DISTRO features, add the grub 'tpm' module to
GRUB_BUILDIN.

This is now required for secureboot to work w/ TPM is also enabled in a
BIOS.