### PR TITLE
Set weak default value for VENDOR_UUID

### DIFF
--- a/meta-signing-key/conf/layer.conf
+++ b/meta-signing-key/conf/layer.conf
@@ -53,7 +53,7 @@ BOOT_KEYS_DIR ??= "${SAMPLE_BOOT_KEYS_DIR}"
 GRUB_PUB_KEY ??= "${BOOT_KEYS_DIR}/boot_pub_key"
 
 # Define the identification of vendor
-VENDOR_UUID = "1f7b9654-2107-4697-8f1c-0cbc38874588"
+VENDOR_UUID ??= "1f7b9654-2107-4697-8f1c-0cbc38874588"
 
 # User configurable identification of signature owner 
 UEFI_SIG_OWNER_GUID ??= "${VENDOR_UUID}"


### PR DESCRIPTION
This fixes the problem of layers required order.

I am using [kas](https://github.com/siemens/kas) for building couple of projects and realized that it uses lexicographic order of the layers. This caused several issues; especially when my layer with Secure Boot keys ended up "above" `meta-signing-key` in `BBLAYERS`. By assigning `VENDOR_UUID` at the very end of parsing, we can have our layers in an arbitrary order.

If you are OK with this change, can you please, cherry-pick this to `gatesgarth` brach, too?

Thank you!