### PR TITLE
kernel-initramfs: fix typo for ALTERNATIVE

### DIFF
--- a/meta/recipes-core/images/kernel-initramfs.bb
+++ b/meta/recipes-core/images/kernel-initramfs.bb
@@ -53,7 +53,7 @@ do_install() {
 
 inherit update-alternatives
 
-ALTERNATIVES_${PN} = ""
+ALTERNATIVE:${PN} = ""
 
 python do_package:prepend () {
     if d.getVar('BUNDLE') == '1':


### PR DESCRIPTION
ALTERNATIVES_${PN} -> ALTERNATIVE:${PN}

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>