### PR TITLE
cryptfs-tpm2: fix ld warnings with binutils 2.39

### DIFF
--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2/0001-env.mk-add-ld-option-noexecstack.patch
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2/0001-env.mk-add-ld-option-noexecstack.patch
@@ -1,0 +1,26 @@
+env.mk: add ld option 'noexecstack'
+
+Add ld option '-z noexecstack' to fix warnings:
+
+  ld: warning: secret_area.o: missing .note.GNU-stack section implies executable stack
+  ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker
+
+Upstream-Status: Pending
+
+Signed-off-by: Kai Kang <kai.kang@windriver.com>
+---
+ env.mk | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/env.mk b/env.mk
+index f250d3a..6370aba 100644
+--- a/env.mk
++++ b/env.mk
+@@ -34,6 +34,7 @@ passphrase_secret ?= h31i05
+ secret_xor_byte_code ?= 0x48
+ 
+ LDFLAGS := -Wl,--warn-common -Wl,--no-undefined -Wl,--fatal-warnings \
++	   -Wl,-z,noexecstack \
+ 	   $(EXTRA_LDFLAGS)
+ CFLAGS := -D_GNU_SOURCE -std=gnu99 -O2 -Wall -Werror \
+ 	  $(addprefix -I, $(TOPDIR)/src/include \

--- a/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
+++ b/meta-encrypted-storage/recipes-tpm/cryptfs-tpm2/cryptfs-tpm2_git.bb
@@ -26,6 +26,7 @@ SRC_URI = "\
     file://0001-Remove-build-time-from-show_banner.patch \
     file://0001-env.mk-fix-LDFLAGS-expansion.patch \
     file://0001-encrypt_secret.py-fix-for-python3.patch \
+    file://0001-env.mk-add-ld-option-noexecstack.patch \
 "
 SRCREV = "62e7f4777495df4aeb0e02d3c761eea6f236f588"
 


### PR DESCRIPTION
Add ld option '-z noexecstack' for cryptfs-tpm2 to fix link warnings:

  ld: warning: secret_area.o: missing .note.GNU-stack section implies executable stack
  ld: NOTE: This behaviour is deprecated and will be removed in a future version of the linker

Signed-off-by: Kai Kang <kai.kang@windriver.com>