### PR TITLE
grub-efi: remove build host references from modinfo.sh

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi-efi-secure-boot.inc
@@ -146,6 +146,14 @@ do_install:append:class-target() {
     # Install the modules to grub-efi's search path
     make -C grub-core install DESTDIR="${D}${EFI_BOOT_PATH}" pkglibdir=""
 
+    # Remove build host references
+    find "${D}${EFI_BOOT_PATH}" -name modinfo.sh -type f -exec \
+        sed -i \
+        -e 's,--sysroot=${STAGING_DIR_TARGET},,g' \
+        -e 's|${DEBUG_PREFIX_MAP}||g' \
+        -e 's:${RECIPE_SYSROOT_NATIVE}::g' \
+        {} +
+
     # Remove .module
     rm -f ${D}${EFI_BOOT_PATH}/${GRUB_TARGET}-efi/*.module
 }


### PR DESCRIPTION
Fix buildpaths warning:
WARNING: grub-efi-2.06-r0 do_package_qa: QA Issue: File /boot/efi/EFI/BOOT/x86_64-efi/modinfo.sh in package grub-efi contains reference to TMPDIR [buildpaths]

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>