### PR TITLE
grub-efi: refresh patches for grub with fix of CVE-2022-28736

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0004-efi-chainloader-port-shim-to-grub.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0004-efi-chainloader-port-shim-to-grub.patch
@@ -1,4 +1,4 @@
-From e097b4e25469aabdceac79c45cca27029824c1b5 Mon Sep 17 00:00:00 2001
+From 061a1200d52bdfc6160cfad5fbe1cef125f8d3a2 Mon Sep 17 00:00:00 2001
 From: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 Date: Fri, 27 Mar 2015 08:19:21 -0700
 Subject: [PATCH 4/7] efi: chainloader: port shim to grub
@@ -22,11 +22,11 @@ Shim can be found here: https://github.com/rhinstaller/shim
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 ---
- grub-core/loader/efi/chainloader.c | 534 +++++++++++++++++++++++++++++++++++++
+ grub-core/loader/efi/chainloader.c | 534 +++++++++++++++++++++++++++++
  1 file changed, 534 insertions(+)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index 3f3e6e3..bd83859 100644
+index 7557eb2..74c84a7 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
 @@ -32,6 +32,7 @@
@@ -37,10 +37,10 @@ index 3f3e6e3..bd83859 100644
  #include <grub/command.h>
  #include <grub/i18n.h>
  #include <grub/net.h>
-@@ -45,6 +46,539 @@ static grub_efi_uintn_t pages;
- static grub_efi_device_path_t *file_path;
- static grub_efi_handle_t image_handle;
- static grub_efi_char16_t *cmdline;
+@@ -43,6 +44,539 @@
+ GRUB_MOD_LICENSE ("GPLv3+");
+ 
+ static grub_dl_t my_mod;
 +static grub_int32_t shim_used;
 +static grub_efi_physical_address_t shim_buffer;
 +static grub_efi_uintn_t shim_pages;
@@ -576,7 +576,7 @@ index 3f3e6e3..bd83859 100644
 +}
  
  static grub_err_t
- grub_chainloader_unload (void)
+ grub_chainloader_unload (void *context)
 -- 
-1.9.1
+2.25.1
 

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0005-efi-chainloader-use-shim-to-load-and-verify-an-image.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0005-efi-chainloader-use-shim-to-load-and-verify-an-image.patch
@@ -1,4 +1,4 @@
-From f922ac74714d01972a3c291e15f0c316b67e40eb Mon Sep 17 00:00:00 2001
+From a99c7ea281b02f14abd0911886cabbea9fc81649 Mon Sep 17 00:00:00 2001
 From: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 Date: Fri, 27 Mar 2015 08:26:08 -0700
 Subject: [PATCH 5/7] efi: chainloader: use shim to load and verify an image
@@ -15,22 +15,22 @@ image is parsed and loaded.
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 ---
- grub-core/loader/efi/chainloader.c | 49 +++++++++++++++++++++++++++++++-------
+ grub-core/loader/efi/chainloader.c | 49 ++++++++++++++++++++++++------
  1 file changed, 40 insertions(+), 9 deletions(-)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index 1f8f061..e988945 100644
+index 74c84a7..667b4c3 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
-@@ -739,6 +739,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
-   char *filename;
-   void *boot_image = 0;
-   grub_efi_handle_t dev_handle = 0;
+@@ -760,6 +760,7 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
+   grub_efi_uintn_t pages = 0;
+   grub_efi_char16_t *cmdline = NULL;
+   grub_efi_handle_t image_handle = NULL;
 +  struct grub_shim_pe_coff_loader_image_context context;
  
    if (argc == 0)
      return grub_error (GRUB_ERR_BAD_ARGUMENT, N_("filename expected"));
-@@ -870,23 +871,53 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
+@@ -886,23 +887,53 @@ grub_cmd_chainloader (grub_command_t cmd __attribute__ ((unused)),
    if (status != GRUB_EFI_SUCCESS)
      {
        if (status == GRUB_EFI_OUT_OF_RESOURCES)
@@ -94,5 +94,5 @@ index 1f8f061..e988945 100644
    if (argc > 1)
      {
 -- 
-1.9.1
+2.25.1
 

--- a/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0007-efi-chainloader-take-care-of-unload-undershim.patch
+++ b/meta-efi-secure-boot/recipes-bsp/grub/grub-efi/0007-efi-chainloader-take-care-of-unload-undershim.patch
@@ -1,4 +1,4 @@
-From 70a30826d1cfb7a90c34760896dfd92b9c396f52 Mon Sep 17 00:00:00 2001
+From c2b23e972b657cdb5e0794c93d342f167fffb3e3 Mon Sep 17 00:00:00 2001
 From: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 Date: Fri, 27 Mar 2015 08:31:27 -0700
 Subject: [PATCH 7/7] efi: chainloader: take care of unload undershim
@@ -10,34 +10,32 @@ sure we free that memory when unloading.
 
 Signed-off-by: Ricardo Neri <ricardo.neri-calderon@linux.intel.com>
 ---
- grub-core/loader/efi/chainloader.c | 14 ++++++++++++--
- 1 file changed, 12 insertions(+), 2 deletions(-)
+ grub-core/loader/efi/chainloader.c | 12 +++++++++++-
+ 1 file changed, 11 insertions(+), 1 deletion(-)
 
 diff --git a/grub-core/loader/efi/chainloader.c b/grub-core/loader/efi/chainloader.c
-index 1c9795c..d0ceb6e 100644
+index baa85be..7b733a7 100644
 --- a/grub-core/loader/efi/chainloader.c
 +++ b/grub-core/loader/efi/chainloader.c
-@@ -586,8 +586,18 @@ grub_chainloader_unload (void)
-   grub_efi_boot_services_t *b;
+@@ -590,7 +590,17 @@ grub_chainloader_unload (void *context)
+     grub_free (loaded_image->load_options);
  
    b = grub_efi_system_table->boot_services;
 -  efi_call_1 (b->unload_image, image_handle);
--  efi_call_2 (b->free_pages, address, pages);
 +  if (!shim_used)
-+    {
-+      efi_call_1 (b->unload_image, image_handle);
-+      efi_call_2 (b->free_pages, address, pages);
-+    }
++  {
++	  efi_call_1 (b->unload_image, image_handle);
++  }
 +  else
-+    {
-+      if (shim_buffer)
-+	{
-+	  efi_call_2 (b->free_pages, shim_buffer, shim_pages);
-+	}
-+    }
++  {
++	  if (shim_buffer)
++	  {
++		  efi_call_2 (b->free_pages, shim_buffer, shim_pages);
++	  }
++  }
  
-   grub_free (file_path);
-   grub_free (cmdline);
+   grub_dl_unref (my_mod);
+   return GRUB_ERR_NONE;
 -- 
-1.9.1
+2.25.1
 


### PR DESCRIPTION
CVE-2022-28736 has 3 patches as below was conflicted with some meta-secure-boot layers patches. 

loader-efi-chainloader-Simplify-the-loader-state.patch 
commands-boot-Add-API-to-pass-context-to-loader.patch 
CVE-2022-28736-loader-efi-chainloader-Use-grub_loader_set_ex.patch

refresh patches to fix the conflict.

Signed-off-by: Xiangyu Chen <xiangyu.chen@windriver.com>