### PR TITLE
meta-integrity: Fix failure to find linux-yocto-integrity.inc

### DIFF
--- a/meta-integrity/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-integrity/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -1,1 +1,1 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', '${BPN}-integrity.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'linux-yocto-integrity.inc', '', d)}

--- a/meta-integrity/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend
+++ b/meta-integrity/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend
@@ -1,1 +1,1 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', '${BPN}-integrity.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'ima', 'linux-yocto-integrity.inc', '', d)}


### PR DESCRIPTION
linux-yocto-integrity.inc is shared among linux-yocto linux-yocto-rt and linux-yocto-dev and cannot be found with ${BPN} in the latter two.

ERROR: ParseError at layers/meta-secure-core/meta-integrity/recipes-kernel/linux/linux-yocto-dev.bbappend:1: Could not include required file linux-yocto-dev-integrity.inc ERROR: ParseError at layers/meta-secure-core/meta-integrity/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend:1: Could not include required file linux-yocto-rt-integrity.inc

Signed-off-by: He Zhe <zhe.he@windriver.com>