### PR TITLE
linux-yocto*: fix require of include file

### DIFF
--- a/meta-tpm2/recipes-kernel/linux/linux-yocto-dev.bbappend
+++ b/meta-tpm2/recipes-kernel/linux/linux-yocto-dev.bbappend
@@ -1,1 +1,1 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', '${BPN}-tpm2.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', 'linux-yocto-tpm2.inc', '', d)}

--- a/meta-tpm2/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend
+++ b/meta-tpm2/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend
@@ -1,1 +1,1 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', '${BPN}-tpm2.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', 'linux-yocto-tpm2.inc', '', d)}

--- a/meta-tpm2/recipes-kernel/linux/linux-yocto_5.%.bbappend
+++ b/meta-tpm2/recipes-kernel/linux/linux-yocto_5.%.bbappend
@@ -1,1 +1,1 @@
-require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', '${BPN}-tpm2.inc', '', d)}
+require ${@bb.utils.contains('DISTRO_FEATURES', 'tpm2', 'linux-yocto-tpm2.inc', '', d)}


### PR DESCRIPTION
There exists only linux-yocto-tpm2.inc. BPN will resolve to linux-yocto-rt and linux-yocto-dev which don't have a recipe specific include files.

Fixes bitbake recipe parsing errors like:

ERROR: ParseError at
/home/builder/src/build/../meta-secure-core/meta-tpm2/recipes-kernel/linux/linux-yocto-rt_5.%.bbappend:1: Could not include required file linux-yocto-rt-tpm2.inc ERROR: Parsing halted due to errors, see error messages above

Signed-off-by: Mikko Rapeli <mikko.rapeli@linaro.org>