### PR TITLE
meta-integrity/conf/layer.conf: rename BBFILE_COLLECTIONS

### DIFF
--- a/meta-integrity/conf/layer.conf
+++ b/meta-integrity/conf/layer.conf
@@ -5,21 +5,21 @@ BBPATH .= ":${LAYERDIR}"
 BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
 	${LAYERDIR}/recipes-*/*/*.bbappend"
 
-BBFILE_COLLECTIONS += "integrity"
-BBFILE_PATTERN_integrity = "^${LAYERDIR}/"
-BBFILE_PRIORITY_integrity = "10"
+BBFILE_COLLECTIONS += "integrity-layer"
+BBFILE_PATTERN_integrity-layer = "^${LAYERDIR}/"
+BBFILE_PRIORITY_integrity-layer = "10"
 
 IMA_SIGNING_BLACKLIST ??= "${LAYERDIR}/files/ima_signing_blacklist"
 
-BBLAYERS_LAYERINDEX_NAME_integrity = "meta-integrity"
+BBLAYERS_LAYERINDEX_NAME_integrity-layer = "meta-integrity"
 
-LAYERDEPENDS_integrity = "\
+LAYERDEPENDS_integrity-layer = "\
     core \
     signing-key \
     openembedded-layer \
 "
 
-LAYERRECOMMENDS_integrity = "\
+LAYERRECOMMENDS_integrity-layer = "\
     tpm2 \
     tpm \
 "
@@ -28,4 +28,4 @@ BB_BASEHASH_IGNORE_VARS:append = " \
     RPM_FSK_PATH \
 "
 
-LAYERSERIES_COMPAT_integrity = "honister kirkstone langdale"
+LAYERSERIES_COMPAT_integrity-layer = "honister kirkstone langdale"


### PR DESCRIPTION
There is already a BBFILE_COLLECTIONS named integrity in meta-security/meta-integrity layer, which will casue conflicts. Rename BBFILE_COLLECTIONS to integrity-layer.

Signed-off-by: Yi Zhao <yi.zhao@windriver.com>