### PR TITLE
shim: fix CVE-2022-28737

### DIFF
--- a/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2022-28737-0001.patch
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2022-28737-0001.patch
@@ -1,0 +1,71 @@
+From 26fd3fbe86fd2681d180049c4207b667a17765f3 Mon Sep 17 00:00:00 2001
+From: Chris Coulson <chris.coulson@canonical.com>
+Date: Tue, 3 May 2022 15:41:00 +0200
+Subject: [PATCH 1/2] pe: Fix a buffer overflow when SizeOfRawData >
+ VirtualSize
+
+During image loading, the size of the destination buffer for the image
+is determined by the SizeOfImage field in the optional header. The start
+and end virtual addresses of each section, as determined by each section's
+VirtualAddress and VirtualSize fields, are bounds checked against the
+allocated buffer. However, the amount of data copied to the destination
+buffer is determined by the section's SizeOfRawData filed. If this is
+larger than the VirtualSize, then the copy can overflow the destination
+buffer.
+
+Fix this by limiting the amount of data to copy to the section's
+VirtualSize. In the case where a section has SizeOfRawData > VirtualSize,
+the excess data is discarded.
+
+This fixes CVE-2022-28737
+
+Signed-off-by: Chris Coulson <chris.coulson@canonical.com>
+
+Upstream-Status: Backport
+CVE: CVE-2022-28737
+
+Reference to upstream patch:
+https://github.com/rhboot/shim/commit/e99bdbb827a50cde019393d3ca1e89397db221a7
+
+[OP: applied changes to shim.c]
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ shim.c | 15 +++++++++------
+ 1 file changed, 9 insertions(+), 6 deletions(-)
+
+diff --git a/shim.c b/shim.c
+index bd314b3..91f8ea4 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1206,6 +1206,7 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+	int i;
+	EFI_IMAGE_SECTION_HEADER *Section;
+	char *base, *end;
++	UINT32 size;
+	PE_COFF_LOADER_IMAGE_CONTEXT context;
+	unsigned int alignment, alloc_size;
+	EFI_PHYSICAL_ADDRESS alloc_address;
+@@ -1377,13 +1378,15 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+				return EFI_UNSUPPORTED;
+			}
+
+-			if (Section->SizeOfRawData > 0)
+-				CopyMem(base, data + Section->PointerToRawData,
+-					Section->SizeOfRawData);
++			size = Section->Misc.VirtualSize;
++			if (size > Section->SizeOfRawData)
++				size = Section->SizeOfRawData;
+
+-			if (Section->SizeOfRawData < Section->Misc.VirtualSize)
+-				ZeroMem(base + Section->SizeOfRawData,
+-					Section->Misc.VirtualSize - Section->SizeOfRawData);
++			if (size > 0)
++				CopyMem(base, data + Section->PointerToRawData, size);
++
++			if (size < Section->Misc.VirtualSize)
++				ZeroMem(base + size, Section->Misc.VirtualSize - size);
+		}
+	}
+
+--
+2.23.0

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2022-28737-0002.patch
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim/CVE-2022-28737-0002.patch
@@ -1,0 +1,81 @@
+From 430b109310c5c1e245a4d1b4cbdb378aae10c343 Mon Sep 17 00:00:00 2001
+From: Peter Jones <pjones@redhat.com>
+Date: Tue, 3 May 2022 17:05:20 -0400
+Subject: [PATCH 2/2] Also avoid CVE-2022-28737 in verify_image()
+
+PR 446 ("Add verify_image") duplicates some of the code affected by
+Chris Coulson's defense in depth patch against CVE-2022-28737 ("pe:
+Perform image verification earlier when loading grub").
+
+This patch makes the same change to the new function.
+
+Signed-off-by: Peter Jones <pjones@redhat.com>
+
+Upstream-Status: Backport
+CVE: CVE-2022-28737
+
+Reference to upstream patch:
+https://github.com/rhboot/shim/commit/159151b6649008793d6204a34d7b9c41221fb4b0
+
+[OP: - applied changes in shim.c
+     - adjusted verify_buffer() context parameter
+     - adjusted console_print() -> console_notify(), dropped console_print()
+       verbose call]
+Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>
+---
+ shim.c | 33 +++++++++++++++++++--------------
+ 1 file changed, 19 insertions(+), 14 deletions(-)
+
+diff --git a/shim.c b/shim.c
+index 91f8ea4..08aa580 100644
+--- a/shim.c
++++ b/shim.c
+@@ -1224,7 +1224,25 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+	}
+
+	/*
+-	 * We only need to verify the binary if we're in secure mode
++	 * Perform the image verification before we start copying data around
++	 * in order to load it.
++	 */
++	if (secure_mode()) {
++		efi_status = verify_buffer(data, datasize,
++					   &context, sha256hash, sha1hash);
++		if (EFI_ERROR(efi_status)) {
++			console_error(L"Verification failed", efi_status);
++			return efi_status;
++		} else if (verbose)
++			console_notify(L"Verification succeeded\n");
++	}
++
++	/*
++	 * Calculate the hash for the TPM measurement.
++	 * XXX: We're computing these twice in secure boot mode when the
++	 *  buffers already contain the previously computed hashes. Also,
++	 *  this is only useful for the TPM1.2 case. We should try to fix
++	 *  this in a follow-up.
+	 */
+	efi_status = generate_hash(data, datasize, &context, sha256hash,
+				   sha1hash);
+@@ -1234,19 +1252,6 @@ static EFI_STATUS handle_image (void *data, unsigned int datasize,
+	/* Measure the binary into the TPM */
+	tpm_log_pe((EFI_PHYSICAL_ADDRESS)(UINTN)data, datasize, sha1hash, 4);
+
+-	if (secure_mode ()) {
+-		efi_status = verify_buffer(data, datasize, &context,
+-					   sha256hash, sha1hash);
+-
+-		if (EFI_ERROR(efi_status)) {
+-			console_error(L"Verification failed", efi_status);
+-			return efi_status;
+-		} else {
+-			if (verbose)
+-				console_notify(L"Verification succeeded");
+-		}
+-	}
+-
+	/* The spec says, uselessly, of SectionAlignment:
+	 * =====
+	 * The alignment (in bytes) of sections when they are loaded into
+--
+2.23.0

--- a/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
+++ b/meta-efi-secure-boot/recipes-bsp/shim/shim_git.bb
@@ -29,6 +29,8 @@ SRC_URI = "\
     file://0012-netboot-replace-the-depreciated-EFI_PXE_BASE_CODE.patch \
     file://0001-MokManager-Use-CompareMem-on-MokListNode.Type-instea.patch \
     file://0001-console.c-Fix-compilation-against-latest-usr-include.patch \
+    file://CVE-2022-28737-0001.patch \
+    file://CVE-2022-28737-0002.patch \
 "
 SRC_URI:append:x86-64 = " \
     ${@bb.utils.contains('DISTRO_FEATURES', 'msft', \


### PR DESCRIPTION
shim: Buffer overflow when loading crafted EFI images.

Reference:
https://nvd.nist.gov/vuln/detail/CVE-2022-2873

Upstream-Status: Backport [https://github.com/rhboot/shim/commit/e99bdbb827a50cde019393d3ca1e89397db221a7, https://github.com/rhboot/shim/commit/159151b6649008793d6204a34d7b9c41221fb4b0]

CVE: CVE-2022-28737

Signed-off-by: Archana Polampalli <archana.polampalli@windriver.com>